### PR TITLE
Redesign UI following Apple HIG

### DIFF
--- a/Foundry.xcodeproj/project.pbxproj
+++ b/Foundry.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		A7B3C4D5E6F7890123456789 /* PluginDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C4D5E6F7890123456789AB /* PluginDetailView.swift */; };
 		C1A2B3C4D5E6F70123456701 /* RefineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3C4D5E6F70123456701AB /* RefineView.swift */; };
 		C1A2B3C4D5E6F70123456702 /* RefineProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3C4D5E6F70123456702AB /* RefineProgressView.swift */; };
+		E3A4B5C6D7E8F90123456703 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B5C6D7E8F90123456703AB /* SettingsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -57,6 +58,7 @@
 		B8C4D5E6F7890123456789AB /* PluginDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDetailView.swift; sourceTree = "<group>"; };
 		D2B3C4D5E6F70123456701AB /* RefineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefineView.swift; sourceTree = "<group>"; };
 		D2B3C4D5E6F70123456702AB /* RefineProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefineProgressView.swift; sourceTree = "<group>"; };
+		F4B5C6D7E8F90123456703AB /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -89,6 +91,7 @@
 				D2B3C4D5E6F70123456701AB /* RefineView.swift */,
 				BB4CE5638194D3E319878858 /* ResultView.swift */,
 				11F0B8ACE372F6DC5016FB8C /* SetupView.swift */,
+				F4B5C6D7E8F90123456703AB /* SettingsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -235,6 +238,7 @@
 				C1A2B3C4D5E6F70123456701 /* RefineView.swift in Sources */,
 				8502215EAB71ADC5A00BED70 /* ResultView.swift in Sources */,
 				46F97EDD013A980C36506FC2 /* SetupView.swift in Sources */,
+				E3A4B5C6D7E8F90123456703 /* SettingsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Foundry/App/FoundryApp.swift
+++ b/Foundry/App/FoundryApp.swift
@@ -1,17 +1,41 @@
 import SwiftUI
 
+enum AppAppearance: String, CaseIterable {
+    case system = "System"
+    case light = "Light"
+    case dark = "Dark"
+
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system: nil
+        case .light: .light
+        case .dark: .dark
+        }
+    }
+}
+
 @main
 struct FoundryApp: App {
     @State private var appState = AppState()
+    @AppStorage("appearance") private var appearance: String = AppAppearance.system.rawValue
+
+    private var colorScheme: ColorScheme? {
+        AppAppearance(rawValue: appearance)?.colorScheme
+    }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environment(appState)
-                .preferredColorScheme(.dark)
+                .preferredColorScheme(colorScheme)
         }
         .defaultSize(width: 900, height: 620)
         .windowResizability(.contentSize)
         .windowToolbarStyle(.unified)
+
+        Settings {
+            SettingsView()
+                .preferredColorScheme(colorScheme)
+        }
     }
 }

--- a/Foundry/Components/PluginCard.swift
+++ b/Foundry/Components/PluginCard.swift
@@ -13,75 +13,55 @@ struct PluginCard: View {
         Button {
             onTap?()
         } label: {
-            VStack(alignment: .leading, spacing: 0) {
-                // Icon header
-                HStack(spacing: 8) {
-                    ZStack {
-                        Circle()
-                            .fill(iconColor.opacity(0.15))
-                            .frame(width: 32, height: 32)
+            HStack(spacing: 10) {
+                // Rounded rect icon — App Store style
+                ZStack {
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .fill(
+                            LinearGradient(
+                                colors: [iconColor, iconColor.opacity(0.6)],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                        )
+                        .frame(width: 36, height: 36)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                .strokeBorder(.white.opacity(0.15), lineWidth: 0.5)
+                        )
 
-                        Image(systemName: plugin.type.systemImage)
-                            .font(.system(size: 13, weight: .medium))
-                            .foregroundStyle(iconColor)
-                    }
+                    Image(systemName: plugin.type.systemImage)
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(.white)
+                }
 
-                    Spacer()
-
-                    // Status indicator
-                    if plugin.status == .failed {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.caption)
-                            .foregroundStyle(.orange)
-                    }
+                // Name + subtitle
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(plugin.name)
+                        .font(.system(size: 13, weight: .regular))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
 
                     Text(plugin.type.displayName)
-                        .font(.caption2.weight(.medium))
-                        .foregroundStyle(.tertiary)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .glassEffect(.regular, in: .capsule)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
                 }
-                .padding(.bottom, 12)
 
-                // Name and description
-                Text(plugin.name)
-                    .font(.headline)
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-                    .padding(.bottom, 4)
+                Spacer(minLength: 4)
 
-                Text(plugin.prompt)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
-                    .multilineTextAlignment(.leading)
-
-                Spacer(minLength: 0)
-
-                // Footer: formats + date
-                HStack(spacing: 6) {
-                    ForEach(plugin.formats, id: \.self) { format in
-                        Text(format.rawValue)
-                            .font(.system(size: 10, weight: .semibold, design: .monospaced))
-                            .foregroundStyle(.tertiary)
-                    }
-
-                    Spacer()
-
-                    Text(plugin.createdAt, style: .date)
-                        .font(.caption2)
-                        .foregroundStyle(.quaternary)
-                }
+                // Action badge — App Store "Get" style
+                Text(plugin.formats.map(\.rawValue).joined(separator: " · "))
+                    .font(.system(size: 10, weight: .bold, design: .rounded))
+                    .foregroundStyle(Color.accentColor)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(Color.accentColor.opacity(0.12), in: .capsule)
             }
-            .padding(14)
-            .frame(height: 170)
+            .padding(.vertical, 8)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 12))
-        .scaleEffect(isHovered ? 1.02 : 1.0)
-        .animation(.easeOut(duration: 0.15), value: isHovered)
         .onHover { hovering in
             isHovered = hovering
         }
@@ -121,15 +101,15 @@ struct PluginCard: View {
 }
 
 #Preview {
-    HStack(spacing: 12) {
+    VStack(spacing: 0) {
         PluginCard(plugin: Plugin.samplePlugins[0])
-            .frame(width: 220)
+        Divider().padding(.leading, 46)
         PluginCard(plugin: Plugin.samplePlugins[1])
-            .frame(width: 220)
+        Divider().padding(.leading, 46)
         PluginCard(plugin: Plugin.samplePlugins[2])
-            .frame(width: 220)
     }
-    .padding(24)
+    .padding(.horizontal, 12)
+    .frame(width: 260)
     .background(.background)
     .preferredColorScheme(.dark)
 }

--- a/Foundry/Views/ErrorView.swift
+++ b/Foundry/Views/ErrorView.swift
@@ -56,10 +56,12 @@ struct ErrorView: View {
                     Text(failureSubtitle)
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: 400)
                 }
 
                 // Details
-                VStack(alignment: .leading, spacing: 6) {
+                VStack(alignment: .leading, spacing: 8) {
                     Text("Details")
                         .font(.caption)
                         .foregroundStyle(.tertiary)
@@ -73,7 +75,7 @@ struct ErrorView: View {
                     }
                     .frame(maxHeight: 120)
                     .padding(12)
-                    .glassEffect(.regular, in: .rect(cornerRadius: 8))
+                    .background(Color(.controlBackgroundColor).opacity(0.3), in: .rect(cornerRadius: 8))
                 }
                 .frame(maxWidth: 480)
             }
@@ -82,22 +84,25 @@ struct ErrorView: View {
         }
         .padding(24)
         .navigationTitle(failureTitle)
-        .navigationBarBackButtonHidden()
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
-                Button("Edit prompt") {
+                Button("Back to Library", systemImage: "chevron.left") {
+                    appState.popToRoot()
+                }
+            }
+            ToolbarItem(placement: .automatic) {
+                Button("Edit Prompt") {
                     appState.popToRoot()
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                         appState.push(.prompt)
                     }
                 }
-                .buttonStyle(.glass)
             }
             ToolbarItem(placement: .primaryAction) {
                 Button("Retry") {
                     appState.push(.generation(config: config))
                 }
-                .buttonStyle(.glassProminent)
+                .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.return, modifiers: .command)
             }
         }

--- a/Foundry/Views/GenerationProgressView.swift
+++ b/Foundry/Views/GenerationProgressView.swift
@@ -76,36 +76,41 @@ struct GenerationProgressView: View {
                 }
 
                 // Step list
-                GlassEffectContainer(spacing: 1) {
-                    VStack(spacing: 1) {
-                        ForEach(GenerationStep.allCases, id: \.self) { step in
-                            HStack(spacing: 10) {
-                                stepIndicator(for: step)
-                                    .frame(width: 16)
+                VStack(spacing: 2) {
+                    ForEach(GenerationStep.allCases, id: \.self) { step in
+                        HStack(spacing: 10) {
+                            stepIndicator(for: step)
+                                .frame(width: 16)
 
-                                Image(systemName: step.icon)
-                                    .font(.system(size: 11))
-                                    .foregroundStyle(stepColor(for: step))
-                                    .frame(width: 16)
+                            Image(systemName: step.icon)
+                                .font(.system(size: 11))
+                                .foregroundStyle(stepColor(for: step))
+                                .frame(width: 16)
 
-                                Text(step.label)
-                                    .font(.subheadline)
-                                    .foregroundStyle(stepColor(for: step))
+                            Text(step.label)
+                                .font(.subheadline)
+                                .foregroundStyle(stepColor(for: step))
 
-                                Spacer()
+                            Spacer()
 
-                                if completedSteps.contains(step.rawValue) {
-                                    Text("Done")
-                                        .font(.caption2)
-                                        .foregroundStyle(.tertiary)
-                                }
+                            if completedSteps.contains(step.rawValue) {
+                                Text("Done")
+                                    .font(.caption2)
+                                    .foregroundStyle(.tertiary)
                             }
-                            .padding(.vertical, 8)
-                            .padding(.horizontal, 12)
-                            .glassEffect(.regular, in: .rect(cornerRadius: 6))
                         }
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 12)
+                        .background(
+                            step == pipeline.currentStep
+                                ? Color.accentColor.opacity(0.06)
+                                : Color.clear,
+                            in: .rect(cornerRadius: 6)
+                        )
                     }
                 }
+                .padding(4)
+                .background(Color(.controlBackgroundColor).opacity(0.3), in: .rect(cornerRadius: 10))
             }
             .frame(maxWidth: 440)
 
@@ -113,7 +118,6 @@ struct GenerationProgressView: View {
         }
         .padding(24)
         .navigationTitle("Building")
-        .navigationBarBackButtonHidden()
         .toolbar {
             ToolbarItem(placement: .automatic) {
                 Text(formattedTime)
@@ -121,12 +125,11 @@ struct GenerationProgressView: View {
                     .foregroundStyle(.tertiary)
             }
             ToolbarItem(placement: .cancellationAction) {
-                Button("Cancel", role: .cancel) {
+                Button("Cancel") {
                     pipeline.cancel()
                     timer?.invalidate()
                     appState.popToRoot()
                 }
-                .buttonStyle(.glass)
             }
         }
         .onAppear {

--- a/Foundry/Views/PluginDetailView.swift
+++ b/Foundry/Views/PluginDetailView.swift
@@ -14,67 +14,81 @@ struct PluginDetailView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header
-            HStack {
-                Spacer()
-                Button {
-                    dismiss()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.subheadline.weight(.medium))
-                        .foregroundStyle(.secondary)
-                        .frame(width: 28, height: 28)
-                        .glassEffect(.regular, in: .circle)
-                }
-                .buttonStyle(.plain)
-            }
-            .padding(.horizontal, 24)
-            .padding(.top, 20)
+            // Colored header
+            ZStack {
+                LinearGradient(
+                    colors: [iconColor.opacity(0.2), iconColor.opacity(0.05)],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .frame(height: 120)
 
-            // Content
-            VStack(spacing: 24) {
-                // Icon + name
-                VStack(spacing: 12) {
+                VStack(spacing: 10) {
                     ZStack {
                         Circle()
-                            .fill(iconColor.opacity(0.15))
-                            .frame(width: 56, height: 56)
+                            .fill(iconColor.opacity(0.25))
+                            .frame(width: 52, height: 52)
 
                         Image(systemName: plugin.type.systemImage)
-                            .font(.system(size: 22, weight: .medium))
+                            .font(.system(size: 20, weight: .semibold))
                             .foregroundStyle(iconColor)
                     }
 
                     Text(plugin.name)
                         .font(.title2)
                         .fontWeight(.semibold)
+                }
+            }
 
+            // Content
+            VStack(spacing: 20) {
+                // Type + status
+                HStack(spacing: 8) {
                     Text(plugin.type.displayName)
                         .font(.caption.weight(.medium))
                         .foregroundStyle(.secondary)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 3)
-                        .glassEffect(.regular, in: .capsule)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+                        .background(.quaternary.opacity(0.5), in: .capsule)
+
+                    if plugin.status == .failed {
+                        Text("Failed")
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.orange)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 4)
+                            .background(.orange.opacity(0.1), in: .capsule)
+                    } else {
+                        Text("Installed")
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.green)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 4)
+                            .background(.green.opacity(0.1), in: .capsule)
+                    }
                 }
 
                 // Info rows
-                VStack(spacing: 1) {
+                VStack(spacing: 0) {
                     infoRow("Prompt", value: plugin.prompt)
+                    Divider().padding(.leading, 80)
                     infoRow("Formats", value: plugin.formats.map(\.rawValue).joined(separator: ", "))
+                    Divider().padding(.leading, 80)
                     infoRow("Created", value: plugin.createdAt.formatted(date: .long, time: .shortened))
-                    infoRow("Status", value: plugin.status.rawValue.capitalized)
 
                     if let au = plugin.installPaths.au {
+                        Divider().padding(.leading, 80)
                         infoRow("AU Path", value: au)
                     }
                     if let vst3 = plugin.installPaths.vst3 {
+                        Divider().padding(.leading, 80)
                         infoRow("VST3 Path", value: vst3)
                     }
                 }
-                .clipShape(.rect(cornerRadius: 8))
+                .background(Color(.controlBackgroundColor).opacity(0.3), in: .rect(cornerRadius: 8))
 
                 // Actions
-                HStack(spacing: 10) {
+                HStack(spacing: 8) {
                     actionButton("Finder", icon: "folder") {
                         onAction?(.showInFinder)
                     }
@@ -92,12 +106,18 @@ struct PluginDetailView: View {
                     }
                 }
             }
-            .padding(.horizontal, 24)
-            .padding(.top, 8)
+            .padding(24)
 
-            Spacer()
+            Spacer(minLength: 0)
         }
         .frame(width: 460, height: 520)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Done") {
+                    dismiss()
+                }
+            }
+        }
     }
 
     // MARK: - Components
@@ -117,7 +137,6 @@ struct PluginDetailView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
-        .background(.quaternary.opacity(0.3))
     }
 
     private func actionButton(
@@ -129,7 +148,7 @@ struct PluginDetailView: View {
         Button(role: role) {
             action()
         } label: {
-            VStack(spacing: 4) {
+            VStack(spacing: 6) {
                 Image(systemName: icon)
                     .font(.body)
                 Text(title)
@@ -139,9 +158,8 @@ struct PluginDetailView: View {
             .frame(height: 52)
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
-        .foregroundStyle(role == .destructive ? .red : .primary)
-        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 8))
+        .buttonStyle(.bordered)
+        .tint(role == .destructive ? .red : nil)
     }
 
     private var iconColor: Color {

--- a/Foundry/Views/PluginLibraryView.swift
+++ b/Foundry/Views/PluginLibraryView.swift
@@ -26,14 +26,9 @@ struct PluginLibraryView: View {
     @State private var renameText = ""
     @State private var deleteError: String?
 
-    private let columns = [
-        GridItem(.adaptive(minimum: 200, maximum: 250), spacing: 12)
-    ]
-
     private var filteredPlugins: [Plugin] {
         var result = appState.plugins
 
-        // Search
         if !searchText.isEmpty {
             let query = searchText.lowercased()
             result = result.filter {
@@ -42,7 +37,6 @@ struct PluginLibraryView: View {
             }
         }
 
-        // Type filter
         switch filter {
         case .all: break
         case .instruments: result = result.filter { $0.type == .instrument }
@@ -50,7 +44,6 @@ struct PluginLibraryView: View {
         case .utilities: result = result.filter { $0.type == .utility }
         }
 
-        // Sort
         switch sort {
         case .newest: result.sort { $0.createdAt > $1.createdAt }
         case .oldest: result.sort { $0.createdAt < $1.createdAt }
@@ -60,62 +53,88 @@ struct PluginLibraryView: View {
         return result
     }
 
+    /// Split into 3 columns, filling left-to-right per row
+    private var columns: [[Plugin]] {
+        var col0: [Plugin] = []
+        var col1: [Plugin] = []
+        var col2: [Plugin] = []
+        for (i, plugin) in filteredPlugins.enumerated() {
+            switch i % 3 {
+            case 0: col0.append(plugin)
+            case 1: col1.append(plugin)
+            default: col2.append(plugin)
+            }
+        }
+        return [col0, col1, col2]
+    }
+
     var body: some View {
         Group {
             if appState.plugins.isEmpty {
                 emptyState
+            } else if filteredPlugins.isEmpty {
+                noResultsState
             } else {
-                VStack(spacing: 0) {
-                    // Toolbar: search + filters
-                    filterBar
-                        .padding(.horizontal, 20)
-                        .padding(.top, 12)
-                        .padding(.bottom, 8)
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 28) {
+                        // Recently created — large cards
+                        if searchText.isEmpty && filter == .all {
+                            recentSection
+                        }
 
-                    if filteredPlugins.isEmpty {
-                        noResultsState
-                    } else {
-                        ScrollView {
-                            // Count
-                            HStack {
-                                Text("\(filteredPlugins.count) plugin\(filteredPlugins.count == 1 ? "" : "s")")
-                                    .font(.caption)
-                                    .foregroundStyle(.tertiary)
+                        // All plugins — App Store grid
+                        VStack(alignment: .leading, spacing: 14) {
+                            HStack(alignment: .firstTextBaseline) {
+                                Text("All Plugins")
+                                    .font(.title3.weight(.semibold))
                                 Spacer()
+                                Text("\(filteredPlugins.count)")
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
                             }
-                            .padding(.horizontal, 20)
-                            .padding(.bottom, 4)
 
-                            LazyVGrid(columns: columns, spacing: 12) {
-                                ForEach(filteredPlugins) { plugin in
-                                    PluginCard(plugin: plugin) {
-                                        selectedPlugin = plugin
-                                    } onDelete: {
-                                        pluginToDelete = plugin
-                                    } onShowInFinder: {
-                                        showInFinder(plugin)
-                                    } onRename: {
-                                        pluginToRename = plugin
-                                        renameText = plugin.name
-                                    } onRegenerate: {
-                                        appState.push(.quickOptions(prompt: plugin.prompt))
-                                    }
-                                }
-                            }
-                            .padding(.horizontal, 20)
-                            .padding(.bottom, 20)
+                            appStoreGrid
                         }
                     }
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 16)
                 }
             }
         }
         .navigationTitle("Foundry")
+        .searchable(text: $searchText, prompt: "Search plugins...")
         .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Button("New Plugin", systemImage: "plus") {
-                    appState.push(.prompt)
+            ToolbarItemGroup(placement: .automatic) {
+                Picker("Filter", selection: $filter) {
+                    ForEach(PluginFilter.allCases, id: \.self) { f in
+                        Text(f.rawValue).tag(f)
+                    }
                 }
-                .buttonStyle(.glassProminent)
+                .pickerStyle(.segmented)
+
+                Menu {
+                    ForEach(PluginSort.allCases, id: \.self) { s in
+                        Button {
+                            sort = s
+                        } label: {
+                            if sort == s {
+                                Label(s.rawValue, systemImage: "checkmark")
+                            } else {
+                                Text(s.rawValue)
+                            }
+                        }
+                    }
+                } label: {
+                    Label("Sort", systemImage: "arrow.up.arrow.down")
+                }
+            }
+
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    appState.push(.prompt)
+                } label: {
+                    Image(systemName: "plus")
+                }
             }
         }
         .sheet(item: $selectedPlugin) { plugin in
@@ -123,25 +142,19 @@ struct PluginLibraryView: View {
                 handleDetailAction(action, for: plugin)
             }
         }
-        // Delete confirmation
         .alert("Delete \(pluginToDelete?.name ?? "plugin")?",
                isPresented: Binding(
                    get: { pluginToDelete != nil },
                    set: { if !$0 { pluginToDelete = nil } }
                )
         ) {
-            Button("Cancel", role: .cancel) {
-                pluginToDelete = nil
-            }
+            Button("Cancel", role: .cancel) { pluginToDelete = nil }
             Button("Delete", role: .destructive) {
-                if let plugin = pluginToDelete {
-                    deletePlugin(plugin)
-                }
+                if let plugin = pluginToDelete { deletePlugin(plugin) }
             }
         } message: {
             Text("This will uninstall the AU/VST3 files from your system. This cannot be undone.")
         }
-        // Rename
         .alert("Rename Plugin",
                isPresented: Binding(
                    get: { pluginToRename != nil },
@@ -149,16 +162,11 @@ struct PluginLibraryView: View {
                )
         ) {
             TextField("Plugin name", text: $renameText)
-            Button("Cancel", role: .cancel) {
-                pluginToRename = nil
-            }
+            Button("Cancel", role: .cancel) { pluginToRename = nil }
             Button("Rename") {
-                if let plugin = pluginToRename {
-                    renamePlugin(plugin, to: renameText)
-                }
+                if let plugin = pluginToRename { renamePlugin(plugin, to: renameText) }
             }
         }
-        // Error
         .alert("Could not delete plugin", isPresented: Binding(
             get: { deleteError != nil },
             set: { if !$0 { deleteError = nil } }
@@ -169,112 +177,166 @@ struct PluginLibraryView: View {
         }
     }
 
-    // MARK: - Filter bar
+    // MARK: - Recent Section
 
-    private var filterBar: some View {
-        HStack(spacing: 12) {
-            // Search
-            HStack(spacing: 6) {
-                Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.tertiary)
-                    .font(.subheadline)
-                TextField("Search plugins...", text: $searchText)
-                    .textFieldStyle(.plain)
-                    .font(.subheadline)
-                if !searchText.isEmpty {
-                    Button {
-                        searchText = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.tertiary)
-                            .font(.caption)
-                    }
-                    .buttonStyle(.plain)
+    private var recentPlugins: [Plugin] {
+        Array(
+            appState.plugins
+                .sorted { $0.createdAt > $1.createdAt }
+                .prefix(2)
+        )
+    }
+
+    private var recentSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Recently Created")
+                .font(.title3.weight(.semibold))
+
+            HStack(spacing: 14) {
+                ForEach(recentPlugins) { plugin in
+                    largePluginCard(plugin)
                 }
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .glassEffect(.regular, in: .capsule)
-            .frame(maxWidth: 240)
+        }
+    }
 
-            // Type filter
-            Picker("Type", selection: $filter) {
-                ForEach(PluginFilter.allCases, id: \.self) { f in
-                    Text(f.rawValue).tag(f)
+    private func largePluginCard(_ plugin: Plugin) -> some View {
+        Button {
+            selectedPlugin = plugin
+        } label: {
+            HStack(spacing: 0) {
+                // Text content — left side
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(plugin.type.displayName)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.secondary)
+
+                    Text(plugin.name)
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+
+                    Text(plugin.prompt)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
                 }
+                .padding(20)
+
+                Spacer(minLength: 0)
+
+                // Circle icon — right side
+                ZStack {
+                    Circle()
+                        .fill(pluginColor(plugin).opacity(0.12))
+                        .frame(width: 80, height: 80)
+
+                    Image(systemName: plugin.type.systemImage)
+                        .font(.system(size: 30, weight: .medium))
+                        .foregroundStyle(pluginColor(plugin))
+                }
+                .padding(.trailing, 20)
             }
-            .pickerStyle(.segmented)
-            .frame(width: 200)
+            .frame(maxWidth: .infinity, minHeight: 120, alignment: .leading)
+            .background(Color(.controlBackgroundColor).opacity(0.5), in: .rect(cornerRadius: 14))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
 
-            Spacer()
+    private func pluginColor(_ plugin: Plugin) -> Color {
+        guard plugin.iconColor.hasPrefix("#"),
+              let hex = UInt(plugin.iconColor.dropFirst(), radix: 16) else {
+            return .accentColor
+        }
+        return Color(
+            .sRGB,
+            red: Double((hex >> 16) & 0xFF) / 255.0,
+            green: Double((hex >> 8) & 0xFF) / 255.0,
+            blue: Double(hex & 0xFF) / 255.0
+        )
+    }
 
-            // Sort
-            Menu {
-                ForEach(PluginSort.allCases, id: \.self) { s in
-                    Button {
-                        sort = s
-                    } label: {
-                        HStack {
-                            Text(s.rawValue)
-                            if sort == s {
-                                Image(systemName: "checkmark")
-                            }
+    // MARK: - App Store Grid
+
+    private var appStoreGrid: some View {
+        HStack(alignment: .top, spacing: 24) {
+            ForEach(0..<3, id: \.self) { colIndex in
+                VStack(spacing: 0) {
+                    let items = columns[colIndex]
+                    ForEach(Array(items.enumerated()), id: \.element.id) { rowIndex, plugin in
+                        if rowIndex > 0 {
+                            Divider()
+                                .padding(.leading, 46)
                         }
+
+                        pluginCardView(for: plugin)
                     }
                 }
-            } label: {
-                Label(sort.rawValue, systemImage: "arrow.up.arrow.down")
-                    .font(.subheadline)
+                .frame(maxWidth: .infinity)
             }
-            .menuStyle(.borderlessButton)
-            .fixedSize()
+        }
+    }
+
+    private func pluginCardView(for plugin: Plugin) -> some View {
+        PluginCard(plugin: plugin) {
+            selectedPlugin = plugin
+        } onDelete: {
+            pluginToDelete = plugin
+        } onShowInFinder: {
+            showInFinder(plugin)
+        } onRename: {
+            pluginToRename = plugin
+            renameText = plugin.name
+        } onRegenerate: {
+            appState.push(.quickOptions(prompt: plugin.prompt))
         }
     }
 
     // MARK: - States
 
     private var emptyState: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 20) {
             Image(systemName: "waveform")
-                .font(.system(size: 40, weight: .thin))
-                .foregroundStyle(.tertiary)
+                .font(.system(size: 48, weight: .thin))
+                .foregroundStyle(.quaternary)
 
-            VStack(spacing: 6) {
+            VStack(spacing: 8) {
                 Text("No plugins yet")
-                    .font(.title3)
+                    .font(.title2)
                     .fontWeight(.medium)
 
                 Text("Create your first audio plugin from a description.")
-                    .font(.subheadline)
+                    .font(.body)
                     .foregroundStyle(.secondary)
             }
 
             Button("New Plugin", systemImage: "plus") {
                 appState.push(.prompt)
             }
-            .buttonStyle(.glassProminent)
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
             .padding(.top, 4)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var noResultsState: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 16) {
             Image(systemName: "magnifyingglass")
-                .font(.system(size: 32, weight: .thin))
-                .foregroundStyle(.tertiary)
+                .font(.system(size: 36, weight: .thin))
+                .foregroundStyle(.quaternary)
 
             Text("No matching plugins")
-                .font(.subheadline)
+                .font(.body)
                 .foregroundStyle(.secondary)
 
             Button("Clear Filters") {
                 searchText = ""
                 filter = .all
             }
-            .font(.subheadline)
-            .buttonStyle(.plain)
-            .foregroundStyle(.tint)
+            .buttonStyle(.bordered)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/Foundry/Views/PromptView.swift
+++ b/Foundry/Views/PromptView.swift
@@ -36,7 +36,7 @@ struct PromptView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 28) {
+            VStack(alignment: .leading, spacing: 24) {
                 // Header
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Describe your plugin")
@@ -47,7 +47,7 @@ struct PromptView: View {
                         .foregroundStyle(.secondary)
                 }
 
-                // Text editor with placeholder
+                // Text editor
                 ZStack(alignment: .topLeading) {
                     TextEditor(text: $prompt)
                         .font(.body)
@@ -65,24 +65,26 @@ struct PromptView: View {
                 }
                 .frame(height: 100)
                 .padding(10)
-                .glassEffect(.regular, in: .rect(cornerRadius: 10))
+                .background(Color(.controlBackgroundColor).opacity(0.3), in: .rect(cornerRadius: 10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .strokeBorder(.quaternary, lineWidth: 1)
+                )
+
+                // Tip
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: "sparkles")
+                        .foregroundStyle(.secondary)
+                        .font(.subheadline)
+                    Text("State whether it is an instrument, effect, or utility. Mention the source material, the primary controls, and whether you want a focused or dense interface.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(14)
+                .background(Color(.controlBackgroundColor).opacity(0.3), in: .rect(cornerRadius: 10))
 
                 // Examples
                 VStack(alignment: .leading, spacing: 20) {
-                    GlassEffectContainer(spacing: 1) {
-                        VStack(alignment: .leading, spacing: 8) {
-                            Label("What helps Foundry generate better plugins", systemImage: "sparkles")
-                                .font(.subheadline.weight(.medium))
-                                .foregroundStyle(.secondary)
-
-                            Text("State whether it is an instrument, effect, or utility. Mention the source material or performance context, the primary controls, and whether you want a focused or dense interface.")
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                        }
-                        .padding(14)
-                        .glassEffect(.regular, in: .rect(cornerRadius: 10))
-                    }
-
                     exampleSection("Instruments", icon: "pianokeys", examples: instrumentExamples)
                     exampleSection("Effects", icon: "waveform", examples: effectExamples)
                     exampleSection("Utilities", icon: "dial.low", examples: utilityExamples)
@@ -97,7 +99,7 @@ struct PromptView: View {
                 Button("Continue") {
                     appState.push(.quickOptions(prompt: prompt))
                 }
-                .buttonStyle(.glassProminent)
+                .buttonStyle(.borderedProminent)
                 .disabled(prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 .keyboardShortcut(.return, modifiers: .command)
             }
@@ -113,25 +115,26 @@ struct PromptView: View {
                 .font(.subheadline.weight(.medium))
                 .foregroundStyle(.tertiary)
 
-            GlassEffectContainer(spacing: 4) {
-                VStack(alignment: .leading, spacing: 4) {
-                    ForEach(examples, id: \.self) { example in
-                        Button {
-                            withAnimation(.easeOut(duration: 0.15)) {
-                                prompt = example
-                            }
-                        } label: {
-                            Text(example)
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.vertical, 6)
-                                .padding(.horizontal, 10)
+            VStack(alignment: .leading, spacing: 2) {
+                ForEach(examples, id: \.self) { example in
+                    Button {
+                        withAnimation(.easeOut(duration: 0.15)) {
+                            prompt = example
                         }
-                        .buttonStyle(.glass)
+                    } label: {
+                        Text(example)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.vertical, 7)
+                            .padding(.horizontal, 10)
+                            .contentShape(Rectangle())
                     }
+                    .buttonStyle(.plain)
                 }
             }
+            .padding(4)
+            .background(Color(.controlBackgroundColor).opacity(0.2), in: .rect(cornerRadius: 8))
         }
     }
 }

--- a/Foundry/Views/QuickOptionsView.swift
+++ b/Foundry/Views/QuickOptionsView.swift
@@ -24,45 +24,49 @@ struct QuickOptionsView: View {
                 }
 
                 // Options
-                GlassEffectContainer(spacing: 1) {
-                    VStack(spacing: 1) {
-                        optionRow("Format", icon: "square.stack.3d.up") {
-                            Picker("Format", selection: $format) {
-                                ForEach(FormatOption.allCases, id: \.self) { option in
-                                    Text(option.rawValue).tag(option)
-                                }
+                VStack(spacing: 0) {
+                    optionRow("Format", icon: "square.stack.3d.up") {
+                        Picker("Format", selection: $format) {
+                            ForEach(FormatOption.allCases, id: \.self) { option in
+                                Text(option.rawValue).tag(option)
                             }
-                            .pickerStyle(.segmented)
-                            .frame(width: 200)
-                        } detail: {
-                            Text("Choose which plugin formats Foundry should build and install.")
                         }
+                        .pickerStyle(.segmented)
+                        .frame(width: 200)
+                    } detail: {
+                        Text("Choose which plugin formats Foundry should build and install.")
+                    }
 
-                        optionRow("Channels", icon: "speaker.wave.2") {
-                            Picker("Channels", selection: $channelLayout) {
-                                ForEach(ChannelLayout.allCases, id: \.self) { option in
-                                    Text(option.rawValue).tag(option)
-                                }
-                            }
-                            .pickerStyle(.segmented)
-                            .frame(width: 160)
-                        } detail: {
-                            Text("Mono keeps the graph simple. Stereo unlocks width and spatial processing.")
-                        }
+                    Divider().padding(.leading, 44)
 
-                        optionRow("Presets", icon: "slider.horizontal.3") {
-                            Picker("Presets", selection: $presetCount) {
-                                ForEach(PresetCount.allCases, id: \.self) { option in
-                                    Text(option.label).tag(option)
-                                }
+                    optionRow("Channels", icon: "speaker.wave.2") {
+                        Picker("Channels", selection: $channelLayout) {
+                            ForEach(ChannelLayout.allCases, id: \.self) { option in
+                                Text(option.rawValue).tag(option)
                             }
-                            .pickerStyle(.segmented)
-                            .frame(width: 200)
-                        } detail: {
-                            Text("Presets push the generator toward more intentional, reusable results.")
                         }
+                        .pickerStyle(.segmented)
+                        .frame(width: 160)
+                    } detail: {
+                        Text("Mono keeps the graph simple. Stereo unlocks width and spatial processing.")
+                    }
+
+                    Divider().padding(.leading, 44)
+
+                    optionRow("Presets", icon: "slider.horizontal.3") {
+                        Picker("Presets", selection: $presetCount) {
+                            ForEach(PresetCount.allCases, id: \.self) { option in
+                                Text(option.label).tag(option)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .frame(width: 200)
+                    } detail: {
+                        Text("Presets push the generator toward more intentional, reusable results.")
                     }
                 }
+                .padding(4)
+                .background(Color(.controlBackgroundColor).opacity(0.3), in: .rect(cornerRadius: 10))
             }
             .padding(24)
             .frame(maxWidth: 520, alignment: .leading)
@@ -73,13 +77,12 @@ struct QuickOptionsView: View {
                 Button("Skip") {
                     startGeneration()
                 }
-                .buttonStyle(.glass)
             }
             ToolbarItem(placement: .primaryAction) {
                 Button("Generate") {
                     startGeneration()
                 }
-                .buttonStyle(.glassProminent)
+                .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.return, modifiers: .command)
             }
         }
@@ -109,7 +112,6 @@ struct QuickOptionsView: View {
         }
         .padding(.vertical, 10)
         .padding(.horizontal, 14)
-        .glassEffect(.regular, in: .rect(cornerRadius: 8))
     }
 
     private func startGeneration() {

--- a/Foundry/Views/RefineProgressView.swift
+++ b/Foundry/Views/RefineProgressView.swift
@@ -49,36 +49,41 @@ struct RefineProgressView: View {
                     }
                 }
 
-                GlassEffectContainer(spacing: 1) {
-                    VStack(spacing: 1) {
-                        ForEach(refineSteps, id: \.self) { step in
-                            HStack(spacing: 10) {
-                                stepIndicator(for: step)
-                                    .frame(width: 16)
+                VStack(spacing: 2) {
+                    ForEach(refineSteps, id: \.self) { step in
+                        HStack(spacing: 10) {
+                            stepIndicator(for: step)
+                                .frame(width: 16)
 
-                                Image(systemName: step.icon)
-                                    .font(.system(size: 11))
-                                    .foregroundStyle(stepColor(for: step))
-                                    .frame(width: 16)
+                            Image(systemName: step.icon)
+                                .font(.system(size: 11))
+                                .foregroundStyle(stepColor(for: step))
+                                .frame(width: 16)
 
-                                Text(step.label)
-                                    .font(.subheadline)
-                                    .foregroundStyle(stepColor(for: step))
+                            Text(step.label)
+                                .font(.subheadline)
+                                .foregroundStyle(stepColor(for: step))
 
-                                Spacer()
+                            Spacer()
 
-                                if completedSteps.contains(step.rawValue) {
-                                    Text("Done")
-                                        .font(.caption2)
-                                        .foregroundStyle(.tertiary)
-                                }
+                            if completedSteps.contains(step.rawValue) {
+                                Text("Done")
+                                    .font(.caption2)
+                                    .foregroundStyle(.tertiary)
                             }
-                            .padding(.vertical, 8)
-                            .padding(.horizontal, 12)
-                            .glassEffect(.regular, in: .rect(cornerRadius: 6))
                         }
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 12)
+                        .background(
+                            step == pipeline.currentStep
+                                ? Color.accentColor.opacity(0.06)
+                                : Color.clear,
+                            in: .rect(cornerRadius: 6)
+                        )
                     }
                 }
+                .padding(4)
+                .background(Color(.controlBackgroundColor).opacity(0.3), in: .rect(cornerRadius: 10))
             }
             .frame(maxWidth: 440)
 
@@ -86,7 +91,6 @@ struct RefineProgressView: View {
         }
         .padding(24)
         .navigationTitle("Refining")
-        .navigationBarBackButtonHidden()
         .toolbar {
             ToolbarItem(placement: .automatic) {
                 Text(formattedTime)
@@ -94,12 +98,11 @@ struct RefineProgressView: View {
                     .foregroundStyle(.tertiary)
             }
             ToolbarItem(placement: .cancellationAction) {
-                Button("Cancel", role: .cancel) {
+                Button("Cancel") {
                     pipeline.cancel()
                     timer?.invalidate()
                     appState.popToRoot()
                 }
-                .buttonStyle(.glass)
             }
         }
         .onAppear {

--- a/Foundry/Views/ResultView.swift
+++ b/Foundry/Views/ResultView.swift
@@ -8,7 +8,7 @@ struct ResultView: View {
         VStack(spacing: 0) {
             Spacer()
 
-            VStack(spacing: 24) {
+            VStack(spacing: 28) {
                 // Success icon
                 ZStack {
                     Circle()
@@ -21,19 +21,19 @@ struct ResultView: View {
                 }
 
                 // Plugin info
-                VStack(spacing: 8) {
+                VStack(spacing: 10) {
                     Text(plugin.name)
                         .font(.title2)
                         .fontWeight(.semibold)
 
                     Text(plugin.type.displayName)
                         .font(.caption.weight(.medium))
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(.secondary)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 4)
-                        .glassEffect(.regular, in: .capsule)
+                        .background(.quaternary.opacity(0.5), in: .capsule)
 
-                    Text("Installed and ready to use")
+                    Text("Installed and ready to use in your DAW")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }
@@ -43,15 +43,15 @@ struct ResultView: View {
                     ForEach(plugin.formats, id: \.self) { format in
                         Label(format.rawValue, systemImage: "checkmark.circle.fill")
                             .font(.subheadline)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(.green)
                             .padding(.horizontal, 12)
                             .padding(.vertical, 6)
-                            .glassEffect(.regular, in: .capsule)
+                            .background(.green.opacity(0.1), in: .capsule)
                     }
                 }
 
                 // Prompt recap
-                VStack(alignment: .leading, spacing: 6) {
+                VStack(alignment: .leading, spacing: 8) {
                     Text("Prompt")
                         .font(.caption)
                         .foregroundStyle(.tertiary)
@@ -61,7 +61,7 @@ struct ResultView: View {
                         .foregroundStyle(.secondary)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(12)
-                        .glassEffect(.regular, in: .rect(cornerRadius: 8))
+                        .background(Color(.controlBackgroundColor).opacity(0.3), in: .rect(cornerRadius: 8))
                 }
                 .frame(maxWidth: 420)
             }
@@ -70,26 +70,28 @@ struct ResultView: View {
         }
         .padding(24)
         .navigationTitle(plugin.name)
-        .navigationBarBackButtonHidden()
         .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Back to Library", systemImage: "chevron.left") {
+                    appState.popToRoot()
+                }
+            }
             ToolbarItem(placement: .automatic) {
                 Button("Show in Finder", systemImage: "folder") {
                     openPluginFolder()
                 }
-                .buttonStyle(.glass)
             }
             ToolbarItem(placement: .automatic) {
                 Button("Refine", systemImage: "slider.horizontal.below.rectangle") {
                     appState.push(.refine(plugin: plugin))
                 }
-                .buttonStyle(.glass)
                 .disabled(plugin.buildDirectory == nil)
             }
             ToolbarItem(placement: .primaryAction) {
                 Button("Done") {
                     appState.popToRoot()
                 }
-                .buttonStyle(.glassProminent)
+                .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.return, modifiers: .command)
             }
         }

--- a/Foundry/Views/SettingsView.swift
+++ b/Foundry/Views/SettingsView.swift
@@ -1,0 +1,210 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @AppStorage("appearance") private var appearance: String = AppAppearance.system.rawValue
+
+    @State private var dependencies: [DependencyStatus] = [
+        DependencyStatus(name: "Xcode CLI Tools", detail: "Compiler toolchain", state: .checking, dependency: .xcodeTools),
+        DependencyStatus(name: "CMake", detail: "Build system", state: .checking, dependency: .cmake),
+        DependencyStatus(name: "JUCE SDK", detail: "Audio framework (~200 MB)", state: .checking, dependency: .juce),
+        DependencyStatus(name: "Claude Code CLI", detail: "npm i -g @anthropic-ai/claude-code", state: .checking, dependency: .claudeCode),
+    ]
+
+    private let pluginPaths = [
+        ("AU Components", "~/Library/Audio/Plug-Ins/Components/"),
+        ("VST3 Plugins", "~/Library/Audio/Plug-Ins/VST3/"),
+        ("Plugin Data", "~/Library/Application Support/Foundry/"),
+    ]
+
+    var body: some View {
+        TabView {
+            generalTab
+                .tabItem {
+                    Label("General", systemImage: "gear")
+                }
+
+            dependenciesTab
+                .tabItem {
+                    Label("Dependencies", systemImage: "shippingbox")
+                }
+        }
+        .frame(width: 480, height: 360)
+    }
+
+    // MARK: - General
+
+    private var generalTab: some View {
+        Form {
+            Section("Appearance") {
+                Picker("Theme", selection: $appearance) {
+                    ForEach(AppAppearance.allCases, id: \.rawValue) { option in
+                        Text(option.rawValue).tag(option.rawValue)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+
+            Section("Plugin Paths") {
+                ForEach(pluginPaths, id: \.0) { label, path in
+                    LabeledContent(label) {
+                        HStack(spacing: 6) {
+                            Text(path)
+                                .font(.system(.body, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+
+                            Button {
+                                let expanded = NSString(string: path).expandingTildeInPath
+                                NSWorkspace.shared.open(URL(fileURLWithPath: expanded))
+                            } label: {
+                                Image(systemName: "folder")
+                                    .font(.caption)
+                            }
+                            .buttonStyle(.borderless)
+                        }
+                    }
+                }
+            }
+
+            Section("About") {
+                LabeledContent("Version") {
+                    Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
+                        .foregroundStyle(.secondary)
+                }
+                LabeledContent("Build") {
+                    Text(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    // MARK: - Dependencies
+
+    private var dependenciesTab: some View {
+        Form {
+            Section {
+                ForEach(Array(dependencies.enumerated()), id: \.element.id) { index, dep in
+                    HStack {
+                        statusIcon(dep.state)
+                            .frame(width: 16)
+
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(dep.name)
+                                .font(.body)
+                            Text(dep.detail)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Spacer()
+
+                        switch dep.state {
+                        case .installing(let progress):
+                            if progress < 0 {
+                                Text("Extracting...")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            } else {
+                                ProgressView(value: progress)
+                                    .frame(width: 60)
+                            }
+                        case .missing:
+                            if dep.dependency == .juce {
+                                Button("Install") {
+                                    installJUCE(index: index)
+                                }
+                                .controlSize(.small)
+                            } else {
+                                Text("Missing")
+                                    .font(.caption)
+                                    .foregroundStyle(.orange)
+                            }
+                        case .installed:
+                            Text("Installed")
+                                .font(.caption)
+                                .foregroundStyle(.green)
+                        case .checking:
+                            EmptyView()
+                        }
+                    }
+                }
+            } header: {
+                Text("Required")
+            } footer: {
+                if dependencies.contains(where: { if case .missing = $0.state { return true }; return false }) {
+                    Text("Install missing dependencies to use Foundry.")
+                        .foregroundStyle(.orange)
+                }
+            }
+
+            Section {
+                Button("Recheck All") {
+                    runChecks()
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .onAppear {
+            runChecks()
+        }
+    }
+
+    // MARK: - Helpers
+
+    @ViewBuilder
+    private func statusIcon(_ state: DependencyStatus.CheckState) -> some View {
+        switch state {
+        case .checking, .installing:
+            ProgressView()
+                .controlSize(.mini)
+        case .installed:
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 14))
+                .foregroundStyle(.green)
+        case .missing:
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 14))
+                .foregroundStyle(.orange)
+        }
+    }
+
+    private func runChecks() {
+        for (index, dep) in dependencies.enumerated() {
+            dependencies[index].state = .checking
+            Task {
+                try? await Task.sleep(for: .milliseconds(index * 150 + 100))
+                let ok = await DependencyChecker.check(dep.dependency)
+                withAnimation(.easeOut(duration: 0.15)) {
+                    dependencies[index].state = ok ? .installed : .missing
+                }
+            }
+        }
+    }
+
+    private func installJUCE(index: Int) {
+        dependencies[index].state = .installing(0)
+        Task {
+            do {
+                try await DependencyChecker.installJUCE { progress in
+                    Task { @MainActor in
+                        dependencies[index].state = .installing(progress)
+                    }
+                }
+                withAnimation(.easeOut(duration: 0.15)) {
+                    dependencies[index].state = .installed
+                }
+            } catch {
+                withAnimation(.easeOut(duration: 0.15)) {
+                    dependencies[index].state = .missing
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    SettingsView()
+        .preferredColorScheme(.dark)
+}


### PR DESCRIPTION
## Summary
- Overhaul plugin library with App Store-style layout: featured cards + compact 3-column grid
- Replace all custom glass effects with native macOS components (`controlBackgroundColor`, standard buttons)
- Add Settings window (Cmd+,) with appearance picker (light/dark/system), dependency status, and plugin paths
- Add back navigation to ResultView, ErrorView, GenerationProgressView, and RefineProgressView
- Add `.searchable()` toolbar search with filter picker and sort menu

## Test plan
- [ ] Verify plugin library renders correctly in light and dark mode
- [ ] Test Settings → Appearance picker switches theme correctly
- [ ] Confirm Cmd+, opens Settings window
- [ ] Navigate through all views and verify back buttons work
- [ ] Check search and filter functionality in library view

🤖 Generated with [Claude Code](https://claude.com/claude-code)