### PR TITLE
fix(pipeline): clean up temp build directories

### DIFF
--- a/Foundry/App/ContentView.swift
+++ b/Foundry/App/ContentView.swift
@@ -38,6 +38,7 @@ struct ContentView: View {
         }
         .onAppear {
             appState.loadPlugins()
+            BuildDirectoryCleaner.sweepStaleDirectories()
         }
         .task {
             await appState.refreshSetupState()

--- a/Foundry/Services/BuildDirectoryCleaner.swift
+++ b/Foundry/Services/BuildDirectoryCleaner.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+enum BuildDirectoryCleaner {
+
+    private static let prefix = "foundry-build-"
+    private static let tmpDirectory = URL(fileURLWithPath: "/tmp")
+    private static let staleThreshold: TimeInterval = 86_400 // 24 hours
+
+    /// Remove a specific build directory after a short grace period.
+    static func cleanAfterInstall(_ directory: URL) {
+        Task.detached(priority: .background) {
+            try? await Task.sleep(for: .seconds(10))
+            try? FileManager.default.removeItem(at: directory)
+        }
+    }
+
+    /// Remove any `/tmp/foundry-build-*` directories older than 24 hours.
+    static func sweepStaleDirectories() {
+        let fm = FileManager.default
+        guard let contents = try? fm.contentsOfDirectory(
+            at: tmpDirectory,
+            includingPropertiesForKeys: [.creationDateKey],
+            options: .skipsHiddenFiles
+        ) else { return }
+
+        let cutoff = Date().addingTimeInterval(-staleThreshold)
+
+        for dir in contents where dir.lastPathComponent.hasPrefix(prefix) {
+            let created = (try? dir.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantPast
+            if created < cutoff {
+                try? fm.removeItem(at: dir)
+            }
+        }
+    }
+}

--- a/Foundry/Services/GenerationPipeline.swift
+++ b/Foundry/Services/GenerationPipeline.swift
@@ -301,11 +301,7 @@ final class GenerationPipeline {
             buildDirectory: project.directory.path
         )
 
-        // Keep temp dir for debugging — can inspect what Claude generated
-        // TODO: re-enable cleanup once generation is stable
-        // Task.detached {
-        //     try? FileManager.default.removeItem(at: project.directory)
-        // }
+        BuildDirectoryCleaner.cleanAfterInstall(project.directory)
 
         return plugin
     }


### PR DESCRIPTION
## Summary
- Add `BuildDirectoryCleaner` service to handle temp build directory cleanup
- On successful install: remove `/tmp/foundry-build-*` dir after 10s grace period
- On app launch: sweep any `foundry-build-*` dirs older than 24 hours
- Failed builds are preserved for inspection (cleanup only runs on success path)

Closes #9

## Test plan
- [x] Verified sweep removes dirs older than 24h and keeps recent ones
- [x] Verified post-install cleanup removes dir (with contents) after delay
- [ ] Manual: generate a plugin, confirm temp dir is cleaned up after ~10s
- [ ] Manual: create a fake `/tmp/foundry-build-test` dir backdated >24h, launch app, confirm removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)