### PR TITLE
fix(pipeline): split build timeout into configure/build, closes #10

### DIFF
--- a/Foundry/Services/BuildRunner.swift
+++ b/Foundry/Services/BuildRunner.swift
@@ -10,7 +10,12 @@ enum BuildRunner {
 
     // MARK: - Build
 
-    static func build(projectDir: URL, skipConfigure: Bool = false, timeoutSeconds: Int = 360) async throws -> BuildResult {
+    static func build(
+        projectDir: URL,
+        skipConfigure: Bool = false,
+        configureTimeout: Int = 60,
+        buildTimeout: Int = 120
+    ) async throws -> BuildResult {
         // 1. Configure with CMake (skip on retries — CMakeLists.txt is never modified)
         if !skipConfigure {
             let configResult = await runProcess(
@@ -18,7 +23,7 @@ enum BuildRunner {
                                         "-DCMAKE_BUILD_TYPE=Release",
                                         "-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64"],
                 workingDirectory: projectDir,
-                timeout: timeoutSeconds
+                timeout: configureTimeout
             )
 
             guard configResult.exitCode == 0 else {
@@ -34,7 +39,7 @@ enum BuildRunner {
         let buildResult = await runProcess(
             "/usr/bin/env", args: ["cmake", "--build", "build", "--config", "Release", "--parallel"],
             workingDirectory: projectDir,
-            timeout: timeoutSeconds
+            timeout: buildTimeout
         )
 
         return BuildResult(


### PR DESCRIPTION
## Summary
- Split the single `timeoutSeconds: 360` parameter into `configureTimeout: 60` and `buildTimeout: 120`
- CMake configure gets 60s, CMake build gets 120s per attempt (matching the design spec)
- Worst-case with 3 retries drops from ~18 min to ~9 min

## Test plan
- [x] Verified the project compiles with no new errors (pre-existing `DependencyListModel` issue unrelated)
- [x] Confirmed all 4 call sites in `GenerationPipeline.swift` use default parameters — no changes needed
- [ ] Manual test: trigger a failing build and verify it times out at ~2 min per attempt instead of ~6 min

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)