### PR TITLE
fix(ci): improve release-please workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,17 +4,45 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    env:
+      RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          release-type: simple
-          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          token: ${{ env.RELEASE_PLEASE_TOKEN }}
+
+      - name: Merge release PR
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ env.RELEASE_PLEASE_TOKEN }}
+          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
+        run: |
+          gh pr merge --merge --delete-branch "$PR_NUMBER"
+          until [ "$(gh pr view "$PR_NUMBER" --json state --jq '.state')" = "MERGED" ]; do
+            sleep 2
+          done
+
+      - name: Publish GitHub release
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        uses: googleapis/release-please-action@v4
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          skip-github-pull-request: true
+          token: ${{ env.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## Summary
- Switch release-please to config/manifest files for better control over versioning
- Add concurrency group to prevent parallel release workflow runs
- Auto-merge release PRs and publish GitHub releases in a single workflow run
- Support dedicated `RELEASE_PLEASE_TOKEN` with `GITHUB_TOKEN` fallback

## Test plan
- [ ] Verify workflow triggers on push to main
- [ ] Confirm release-please creates a release PR with correct changelog
- [ ] Validate auto-merge step merges the PR and publishes the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)