### PR TITLE
fix: move checkout before release-please action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,15 +20,15 @@ jobs:
     env:
       RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           token: ${{ env.RELEASE_PLEASE_TOKEN }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
       
       - name: Merge release PR
         if: ${{ steps.release.outputs.prs_created == 'true' }}


### PR DESCRIPTION
## Summary
- The release workflow failed with `fatal: not a git repository` because `release-please-action` ran before `actions/checkout`
- Moved the checkout step to run first so the repo is cloned before any git commands execute

## Test plan
- [ ] Verify the release workflow passes on the next push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)