### PR TITLE
fix: prevent C++ build errors in generated plugins

### DIFF
--- a/Foundry/Services/ClaudeCodeService.swift
+++ b/Foundry/Services/ClaudeCodeService.swift
@@ -183,7 +183,14 @@ enum ClaudeCodeService {
             "--max-turns", "50",
             "--model", "sonnet",
             "--append-system-prompt",
-            "You MUST use tools (Read, Edit, Write, Bash) on every turn. Never respond with only text — always take action by reading or editing files.",
+            """
+            You MUST use tools (Read, Edit, Write, Bash) on every turn. Never respond with only text — always take action by reading or editing files.
+            CRITICAL C++ RULES:
+            - Use `const auto&` to iterate value types (std::pair, struct). NEVER `auto*` — that is a pointer dereference and will not compile.
+            - Never add a new definition for a method that already exists in the .cpp file. Use Edit to MODIFY the existing implementation.
+            - All JUCE types must be fully qualified with juce:: prefix.
+            - Use juce::Font(juce::FontOptions(float)) — never juce::Font(float).
+            """,
         ]
     }
 

--- a/Foundry/Services/GenerationPipeline.swift
+++ b/Foundry/Services/GenerationPipeline.swift
@@ -120,25 +120,20 @@ final class GenerationPipeline {
             ? "\n- Implement exactly \(presetCount) presets with a ComboBox selector in the UI (see CLAUDE.md Presets section)"
             : ""
         let genPrompt = """
-        IMPORTANT: Read CLAUDE.md first — it contains your expert knowledge and the plugin brief.
-        Then write the plugin code into the source files using your tools. Act immediately.
+        You are building a JUCE \(pluginRole) plugin: \(config.prompt)
+        Archetype: \(project.pluginType.displayName) | Interface: \(project.interfaceStyle.rawValue)
 
-        You are building a JUCE \(pluginRole) plugin from minimal stubs.
+        ## Step-by-step instructions — follow in order:
 
-        Brief: \(config.prompt)
-        Archetype: \(project.pluginType.displayName)
-        Interface style: \(project.interfaceStyle.rawValue)
+        1. **Read CLAUDE.md** — it contains your expert JUCE knowledge, DSP patterns, and constraints.
+        2. **Read all Source/ files** — PluginProcessor.h, PluginProcessor.cpp, PluginEditor.h, PluginEditor.cpp, FoundryLookAndFeel.h. Understand the existing stubs before editing.
+        3. **Implement parameters** — Edit PluginProcessor.cpp: add AudioParameterFloat/Choice/Bool in createParameterLayout(). Add SmoothedValue members in the header. You need at least 3-5 parameters appropriate for this plugin.
+        4. **Implement DSP** — Edit processBlock() with real audio processing logic. Read parameter values, apply smoothing, process samples. This must be substantial (not just pass-through).\(project.pluginType == .instrument ? " Also implement voice rendering in renderNextBlock()." : "")
+        5. **Build the editor** — Add sliders, labels, and attachments in PluginEditor.h and .cpp. Every parameter MUST have a matching visible UI control with addAndMakeVisible(). Wire them with SliderAttachment/ComboBoxAttachment.
+        6. **Set accent colour** — Edit FoundryLookAndFeel.h accentColour to match the plugin character.\(presetInstruction)
 
-        The source files have correct class names and method signatures with empty bodies.
-        Your job:
-        1. Read CLAUDE.md for expert JUCE knowledge and constraints
-        2. Implement parameters in createParameterLayout()
-        3. Implement DSP in processBlock()\(project.pluginType == .instrument ? " and voice rendering" : "")
-        4. Build the editor with appropriate controls for every parameter
-        5. Set accentColour in FoundryLookAndFeel.h to match the plugin character\(presetInstruction)
-
-        Write production-quality code. Every parameter needs a matching UI control.
-        Keep class names unchanged. Must compile with C++17 and JUCE.
+        CRITICAL: Use Edit tool to modify existing method bodies. Do NOT add duplicate method definitions.
+        Use `const auto&` for iteration — NEVER `auto*` on value types.
         """
         let genResult = await ClaudeCodeService.run(
             prompt: genPrompt,

--- a/Foundry/Services/ProjectAssembler.swift
+++ b/Foundry/Services/ProjectAssembler.swift
@@ -274,10 +274,10 @@ enum ProjectAssembler {
             bool producesMidi() const override { return false; }
             double getTailLengthSeconds() const override { return 0.0; }
 
-            int getNumPrograms() override { return 1; }
-            int getCurrentProgram() override { return 0; }
-            void setCurrentProgram(int) override {}
-            const juce::String getProgramName(int) override { return {}; }
+            int getNumPrograms() override;
+            int getCurrentProgram() override;
+            void setCurrentProgram(int index) override;
+            const juce::String getProgramName(int index) override;
             void changeProgramName(int, const juce::String&) override {}
 
             void getStateInformation(juce::MemoryBlock& destData) override;
@@ -367,6 +367,11 @@ enum ProjectAssembler {
         {
             return new \(pluginName)Editor(*this);
         }
+
+        int \(pluginName)Processor::getNumPrograms() { return 1; }
+        int \(pluginName)Processor::getCurrentProgram() { return 0; }
+        void \(pluginName)Processor::setCurrentProgram(int) {}
+        const juce::String \(pluginName)Processor::getProgramName(int) { return {}; }
 
         juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
         {
@@ -626,17 +631,22 @@ enum ProjectAssembler {
             int currentPreset = 0;
             ```
 
-            ### In PluginProcessor.cpp:
-            ```cpp
-            int getNumPrograms() override { return \(presetCount); }
-            int getCurrentProgram() override { return currentPreset; }
-            const juce::String getProgramName(int index) override { return presets[index].name; }
+            ### In PluginProcessor.cpp — use Edit to MODIFY the existing one-liner stubs:
+            The file already contains these methods with stub bodies. Use your Edit tool to replace their bodies:
+            - `getNumPrograms()` → return \(presetCount);
+            - `getCurrentProgram()` → return currentPreset;
+            - `getProgramName(int index)` → return presets[index].name;
+            - `setCurrentProgram(int index)` → apply preset values via apvts
 
-            void setCurrentProgram(int index) override
+            **DO NOT add new method definitions — they already exist. Edit them in place.**
+
+            ```cpp
+            // setCurrentProgram implementation pattern:
+            void \(pluginName)Processor::setCurrentProgram(int index)
             {
                 if (index < 0 || index >= getNumPrograms()) return;
                 currentPreset = index;
-                for (auto& [paramId, value] : presets[index].values)
+                for (const auto& [paramId, value] : presets[index].values)
                     if (auto* param = apvts.getParameter(paramId))
                         param->setValueNotifyingHost(param->convertTo0to1(value));
             }
@@ -825,6 +835,18 @@ enum ProjectAssembler {
             mySlider.setBounds(section.reduced(10));
         }
         ```
+
+        ### C++ rules (WILL NOT COMPILE IF VIOLATED):
+        - **Iteration**: `for (const auto& item : container)` — NEVER `for (auto* item : container)`. The `auto*` syntax is ONLY for pointer return values. Using `auto*` on a `std::pair` or struct WILL NOT COMPILE.
+          ```cpp
+          // CORRECT:
+          for (const auto& [slider, label] : sliderPairs) { ... }
+          for (const auto& pair : myPairs) { pair.first->setBounds(...); }
+          // WRONG — WILL NOT COMPILE:
+          for (auto* pair : myPairs) { ... }
+          ```
+        - **No duplicate definitions**: Methods like getNumPrograms(), getCurrentProgram(), etc. already exist in PluginProcessor.cpp. Use Edit to MODIFY them — do NOT add new definitions or you get "redefinition" errors.
+        - All method signatures in .cpp must match .h declarations exactly.
 
         ### Visual rules:
         - Dark background (0xff0a0a0a to 0xff181818), one muted accent colour


### PR DESCRIPTION
## Summary
- Fix `auto*` vs `const auto&` errors by adding C++ rules to Claude's system prompt and generated CLAUDE.md with correct/wrong examples
- Fix `redefinition of getCurrentProgram` by moving program method implementations from header to .cpp stubs, and rewriting preset instructions to explicitly use Edit instead of adding new definitions
- Fix incomplete generation (empty params, DSP, UI) by making the generation prompt step-by-step with concrete requirements (3-5 params, matching UI controls, substantial DSP)

## Test plan
- [ ] Generate an effect plugin (e.g. "warm tape delay") — should compile without `auto*` or redefinition errors
- [ ] Generate a plugin with presets — program methods should be edited in place, not duplicated
- [ ] Quality enforcer should pass on first attempt (parameters, DSP, UI controls present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)