### PR TITLE
fix: remove AI slop design, use native macOS patterns

### DIFF
--- a/Foundry/App/ContentView.swift
+++ b/Foundry/App/ContentView.swift
@@ -46,6 +46,7 @@ struct ContentView: View {
             appState.loadPlugins()
             BuildDirectoryCleaner.sweepStaleDirectories()
         }
+        .frame(minWidth: 900, minHeight: 620)
         .task {
             await appState.refreshSetupState()
         }

--- a/Foundry/App/FoundryApp.swift
+++ b/Foundry/App/FoundryApp.swift
@@ -35,7 +35,7 @@ struct FoundryApp: App {
                 .preferredColorScheme(colorScheme)
         }
         .defaultSize(width: 900, height: 620)
-        .windowResizability(.contentSize)
+        .windowResizability(.contentMinSize)
         .windowToolbarStyle(.unified)
 
         Settings {

--- a/Foundry/Components/AbstractArtwork.swift
+++ b/Foundry/Components/AbstractArtwork.swift
@@ -28,7 +28,7 @@ struct WaveformBarsArtwork: View {
             HStack(alignment: .bottom, spacing: 2) {
                 ForEach(Array(bars.enumerated()), id: \.offset) { _, bar in
                     Rectangle()
-                        .fill(Color.white.opacity(bar.opacity))
+                        .fill(Color.primary.opacity(bar.opacity))
                         .frame(width: 3, height: geo.size.height * bar.height * 0.85)
                 }
             }
@@ -38,7 +38,7 @@ struct WaveformBarsArtwork: View {
         }
         .overlay(
             LinearGradient(
-                colors: [FoundryTheme.Colors.backgroundCard, FoundryTheme.Colors.backgroundCard.opacity(0)],
+                colors: [Color.clear.opacity(0.5), Color.clear],
                 startPoint: .top,
                 endPoint: .center
             )
@@ -55,7 +55,7 @@ struct ConcentricRingsArtwork: View {
                 .strokeBorder(FoundryTheme.Colors.borderSubtle, lineWidth: 1)
                 .frame(width: 96, height: 96)
             Circle()
-                .strokeBorder(Color.white.opacity(0.8), lineWidth: 2)
+                .strokeBorder(Color.primary.opacity(0.8), lineWidth: 2)
                 .frame(width: 64, height: 64)
             Circle()
                 .strokeBorder(FoundryTheme.Colors.textSecondary.opacity(0.4), lineWidth: 1)

--- a/Foundry/Components/CustomShapes.swift
+++ b/Foundry/Components/CustomShapes.swift
@@ -61,24 +61,3 @@ extension View {
     }
 }
 
-// MARK: - Semi Arc
-
-/// Half-circle arc used for progress indicators.
-struct SemiArc: Shape {
-    var progress: Double
-
-    var animatableData: Double {
-        get { progress }
-        set { progress = newValue }
-    }
-
-    func path(in rect: CGRect) -> Path {
-        var p = Path()
-        let center = CGPoint(x: rect.midX, y: rect.midY)
-        let radius = min(rect.width, rect.height) / 2
-        let startAngle = Angle(degrees: 180)
-        let endAngle = Angle(degrees: 180 + progress * 180)
-        p.addArc(center: center, radius: radius, startAngle: startAngle, endAngle: endAngle, clockwise: false)
-        return p
-    }
-}

--- a/Foundry/Components/DependencyListModel.swift
+++ b/Foundry/Components/DependencyListModel.swift
@@ -15,11 +15,8 @@ final class DependencyListModel {
         for (index, dep) in dependencies.enumerated() {
             dependencies[index].state = .checking
             Task {
-                try? await Task.sleep(for: .milliseconds(index * 200 + 100))
                 let ok = await DependencyChecker.check(dep.dependency)
-                withAnimation(.easeOut(duration: 0.15)) {
-                    dependencies[index].state = ok ? .installed : .missing
-                }
+                dependencies[index].state = ok ? .installed : .missing
                 checkAllDone()
             }
         }
@@ -34,14 +31,10 @@ final class DependencyListModel {
                         self.dependencies[index].state = .installing(progress)
                     }
                 }
-                withAnimation(.easeOut(duration: 0.15)) {
-                    dependencies[index].state = .installed
-                }
+                dependencies[index].state = .installed
                 checkAllDone()
             } catch {
-                withAnimation(.easeOut(duration: 0.15)) {
-                    dependencies[index].state = .missing
-                }
+                dependencies[index].state = .missing
             }
         }
     }
@@ -56,9 +49,7 @@ final class DependencyListModel {
             return false
         }
         if allInstalled {
-            withAnimation(.easeOut(duration: 0.15).delay(0.2)) {
-                allReady = true
-            }
+            allReady = true
         }
     }
 }

--- a/Foundry/Components/FoundryHeaderBar.swift
+++ b/Foundry/Components/FoundryHeaderBar.swift
@@ -93,7 +93,7 @@ struct FilterTab: View {
                     .foregroundStyle(isActive ? FoundryTheme.Colors.textPrimary : FoundryTheme.Colors.textSecondary)
                     .frame(height: 44)
                 Rectangle()
-                    .fill(isActive ? Color.white : Color.clear)
+                    .fill(isActive ? Color.primary : Color.clear)
                     .frame(height: 2)
             }
         }
@@ -114,10 +114,10 @@ struct FoundryActionButton: View {
             Text(title)
                 .font(FoundryTheme.Fonts.azeretMono(12))
                 .tracking(0.5)
-                .foregroundStyle(Color(hex: 0x1A1C1C))
+                .foregroundStyle(Color(.windowBackgroundColor))
                 .padding(.horizontal, FoundryTheme.Spacing.lg)
                 .padding(.vertical, FoundryTheme.Spacing.xs)
-                .background(Color.white)
+                .background(Color.primary)
                 .clipShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/Foundry/Components/FoundryTheme.swift
+++ b/Foundry/Components/FoundryTheme.swift
@@ -21,25 +21,25 @@ enum FoundryTheme {
     // MARK: Colors
 
     enum Colors {
-        static let background = Color.black
-        static let backgroundDeep = Color(hex: 0x0A0A0A)
-        static let backgroundCard = Color(hex: 0x0E0E0E)
-        static let backgroundElevated = Color(hex: 0x131313)
-        static let backgroundToolbar = Color(hex: 0x1B1B1B)
-        static let backgroundSubtle = Color(hex: 0x1A1A1A)
+        static let background = Color(.windowBackgroundColor)
+        static let backgroundDeep = Color(.controlBackgroundColor)
+        static let backgroundCard = Color(.controlBackgroundColor)
+        static let backgroundElevated = Color(.underPageBackgroundColor)
+        static let backgroundToolbar = Color(.windowBackgroundColor)
+        static let backgroundSubtle = Color(.controlBackgroundColor)
 
-        static let border = Color(hex: 0x333333)
-        static let borderSubtle = Color(hex: 0x474747)
+        static let border = Color(.separatorColor)
+        static let borderSubtle = Color(.tertiaryLabelColor).opacity(0.3)
 
-        static let textPrimary = Color.white
-        static let textSecondary = Color(hex: 0x919191)
-        static let textMuted = Color(hex: 0x666666)
-        static let textDimmed = Color(hex: 0x555555)
-        static let textFaint = Color(hex: 0x444444)
+        static let textPrimary = Color(.labelColor)
+        static let textSecondary = Color(.secondaryLabelColor)
+        static let textMuted = Color(.tertiaryLabelColor)
+        static let textDimmed = Color(.quaternaryLabelColor)
+        static let textFaint = Color(.quaternaryLabelColor).opacity(0.6)
 
-        static let trafficRed = Color(hex: 0xFF5F56)
-        static let trafficYellow = Color(hex: 0xFFBD2E)
-        static let trafficGreen = Color(hex: 0x27C93F)
+        static let trafficRed = Color.red
+        static let trafficYellow = Color.yellow
+        static let trafficGreen = Color.green
     }
 
     // MARK: Fonts

--- a/Foundry/Components/PluginArtworkView.swift
+++ b/Foundry/Components/PluginArtworkView.swift
@@ -21,9 +21,9 @@ struct PluginArtworkView: View {
         .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                .strokeBorder(.white.opacity(0.16), lineWidth: 0.5)
+                .strokeBorder(Color.primary.opacity(0.16), lineWidth: 0.5)
         )
-        .shadow(color: .black.opacity(0.18), radius: size * 0.14, y: size * 0.08)
+        .shadow(color: Color.primary.opacity(0.12), radius: size * 0.14, y: size * 0.08)
     }
 
     private var fallbackArtwork: some View {
@@ -36,7 +36,7 @@ struct PluginArtworkView: View {
 
             Image(systemName: plugin.type.systemImage)
                 .font(.system(size: symbolSize, weight: .medium))
-                .foregroundStyle(.white)
+                .foregroundStyle(.primary)
         }
     }
 

--- a/Foundry/Components/TerminalView.swift
+++ b/Foundry/Components/TerminalView.swift
@@ -10,19 +10,10 @@ struct TerminalView: View {
     var streamingText: String = ""
     var showCursor: Bool = true
 
-    @State private var cursorVisible = true
-
     var body: some View {
         VStack(spacing: 0) {
             terminalHeader
             terminalBody
-        }
-        .task {
-            guard showCursor else { return }
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .milliseconds(600))
-                cursorVisible.toggle()
-            }
         }
     }
 
@@ -48,12 +39,49 @@ struct TerminalView: View {
                 .tracking(1)
                 .foregroundStyle(FoundryTheme.Colors.textMuted)
                 .monospacedDigit()
+
+            Menu {
+                Button("Copy Logs", systemImage: "doc.on.doc") {
+                    copyLogs()
+                }
+                Button("Export as .txt…", systemImage: "square.and.arrow.up") {
+                    exportLogs()
+                }
+            } label: {
+                Image(systemName: "ellipsis.circle")
+                    .font(.system(size: 12))
+                    .foregroundStyle(FoundryTheme.Colors.textMuted)
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
         }
         .padding(.horizontal, FoundryTheme.Spacing.lg)
         .frame(height: 40)
-        .background(Color.black.opacity(0.4))
+        .background(Color(.controlBackgroundColor))
         .overlay(alignment: .bottom) {
-            Rectangle().fill(Color.white.opacity(0.1)).frame(height: 1)
+            Rectangle().fill(Color(.separatorColor)).frame(height: 1)
+        }
+    }
+
+    // MARK: - Actions
+
+    private var logsText: String {
+        logLines.map { "[\($0.timestamp)] \($0.message)" }.joined(separator: "\n")
+    }
+
+    private func copyLogs() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(logsText, forType: .string)
+    }
+
+    private func exportLogs() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.plainText]
+        panel.nameFieldStringValue = "build-log.txt"
+        panel.begin { response in
+            if response == .OK, let url = panel.url {
+                try? logsText.write(to: url, atomically: true, encoding: .utf8)
+            }
         }
     }
 
@@ -79,7 +107,7 @@ struct TerminalView: View {
                                 .padding(.top, 1)
                             Text(streamingText)
                                 .font(FoundryTheme.Fonts.jetBrainsMono(11))
-                                .foregroundStyle(Color.white.opacity(0.35))
+                                .foregroundStyle(Color.primary.opacity(0.35))
                                 .fixedSize(horizontal: false, vertical: true)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
@@ -88,9 +116,9 @@ struct TerminalView: View {
                     }
 
                     if showCursor {
-                        Text(cursorVisible ? "_" : " ")
+                        Text("_")
                             .font(FoundryTheme.Fonts.jetBrainsMono(11))
-                            .foregroundStyle(.white)
+                            .foregroundStyle(.primary)
                             .id("cursor")
                     }
                 }
@@ -125,7 +153,7 @@ struct TerminalLineView: View {
                     .padding(.top, 1)
                 Text(line.message)
                     .font(FoundryTheme.Fonts.jetBrainsMono(11))
-                    .foregroundStyle(Color.white.opacity(0.6))
+                    .foregroundStyle(Color.primary.opacity(0.6))
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
             case .success:
@@ -137,32 +165,32 @@ struct TerminalLineView: View {
                     .padding(.top, 1)
                 Text(line.message)
                     .font(FoundryTheme.Fonts.jetBrainsMono(11))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.primary)
                     .fontWeight(.bold)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
             case .active:
                 Text("->")
                     .font(FoundryTheme.Fonts.jetBrainsMono(11))
-                    .foregroundStyle(Color.white.opacity(0.6))
+                    .foregroundStyle(Color.primary.opacity(0.6))
                     .lineLimit(1)
                     .frame(width: 82, alignment: .leading)
                     .padding(.top, 1)
                 Text(line.message)
                     .font(FoundryTheme.Fonts.jetBrainsMono(11))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.primary)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
             case .error:
                 Text("[ERR]")
                     .font(FoundryTheme.Fonts.jetBrainsMono(11))
-                    .foregroundStyle(Color(hex: 0xFF5F56))
+                    .foregroundStyle(Color.red)
                     .lineLimit(1)
                     .frame(width: 82, alignment: .leading)
                     .padding(.top, 1)
                 Text(line.message)
                     .font(FoundryTheme.Fonts.jetBrainsMono(11))
-                    .foregroundStyle(Color(hex: 0xFF5F56))
+                    .foregroundStyle(Color.red)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }

--- a/Foundry/Services/GenerationPipeline.swift
+++ b/Foundry/Services/GenerationPipeline.swift
@@ -393,9 +393,7 @@ final class GenerationPipeline {
 
     private func setStep(_ step: GenerationStep) {
         let prev = currentStep
-        withAnimation(.easeInOut(duration: 0.2)) {
-            currentStep = step
-        }
+        currentStep = step
         if step != prev {
             let completionMap: [GenerationStep: String] = [
                 .preparingProject: "PREPARING PROJECT: Dependencies resolved.",

--- a/Foundry/Views/ErrorView.swift
+++ b/Foundry/Views/ErrorView.swift
@@ -7,25 +7,25 @@ struct ErrorView: View {
 
     private var failureTitle: String {
         if message.localizedCaseInsensitiveContains("incomplete") || message.localizedCaseInsensitiveContains("insufficient") {
-            return "IMPLEMENTATION INCOMPLETE"
+            return "Implementation Incomplete"
         }
         if message.localizedCaseInsensitiveContains("timed out") {
-            return "GENERATION TIMED OUT"
+            return "Generation Timed Out"
         }
         if message.localizedCaseInsensitiveContains("compile") || message.localizedCaseInsensitiveContains("error:") {
-            return "BUILD FAILED"
+            return "Build Failed"
         }
-        return "GENERATION FAILED"
+        return "Generation Failed"
     }
 
     private var failureSubtitle: String {
         switch failureTitle {
-        case "IMPLEMENTATION INCOMPLETE":
+        case "Implementation Incomplete":
             return "The generated plugin was missing key implementations (parameters, DSP, or UI controls)."
-        case "GENERATION TIMED OUT":
+        case "Generation Timed Out":
             return "The code generator did not finish within the allowed time."
-        case "BUILD FAILED":
-            return "Foundry could not compile the plugin after 3 attempts."
+        case "Build Failed":
+            return "Foundry could not compile the plugin after multiple attempts."
         default:
             return "Foundry could not finish a usable plugin from this brief."
         }
@@ -33,154 +33,77 @@ struct ErrorView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            WindowChromeBar(title: "BUILD_FAILED.SH")
-            topNav
-            mainContent
-            actionBar
-        }
-        .background(FoundryTheme.Colors.background)
-        .navigationBarBackButtonHidden(true)
-        .toolbar(.hidden)
-    }
-
-    // MARK: - Top Nav
-
-    private var topNav: some View {
-        HStack {
-            Text("FOUNDRY")
-                .font(FoundryTheme.Fonts.spaceGrotesk(20))
-                .tracking(1)
-                .foregroundStyle(.white)
-
-            Spacer()
-
-            HStack(spacing: FoundryTheme.Spacing.xs) {
-                Circle()
-                    .fill(FoundryTheme.Colors.trafficRed)
-                    .frame(width: 6, height: 6)
-                Text("BUILD FAILED")
-                    .font(FoundryTheme.Fonts.azeretMono(11))
-                    .tracking(0.9)
-                    .foregroundStyle(FoundryTheme.Colors.trafficRed)
-            }
-            .padding(.horizontal, 13)
-            .padding(.vertical, 5)
-            .foundryBorder(background: FoundryTheme.Colors.backgroundSubtle, border: Color.white.opacity(0.1))
-        }
-        .padding(.horizontal, FoundryTheme.Spacing.xl)
-        .frame(height: FoundryTheme.Layout.headerHeight)
-        .background(FoundryTheme.Colors.background)
-        .overlay(alignment: .bottom) {
-            Rectangle().fill(FoundryTheme.Colors.border).frame(height: 1)
-        }
-    }
-
-    // MARK: - Main Content
-
-    private var mainContent: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                errorHeader
-                    .padding(.bottom, FoundryTheme.Spacing.xxl)
-
-                errorDetails
-            }
-            .frame(maxWidth: 680)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, FoundryTheme.Spacing.xl)
-            .padding(.vertical, FoundryTheme.Spacing.xxl)
-        }
-        .background(FoundryTheme.Colors.backgroundElevated)
-    }
-
-    private var errorHeader: some View {
-        VStack(alignment: .leading, spacing: FoundryTheme.Spacing.md) {
-            Text(failureTitle)
-                .font(FoundryTheme.Fonts.spaceGrotesk(48))
-                .tracking(1)
-                .foregroundStyle(.white)
-                .lineLimit(2)
-                .minimumScaleFactor(0.6)
-
-            Text(failureSubtitle)
-                .font(FoundryTheme.Fonts.azeretMono(13))
-                .foregroundStyle(FoundryTheme.Colors.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-
-    private var errorDetails: some View {
-        VStack(alignment: .leading, spacing: FoundryTheme.Spacing.xs) {
-            Text("ERROR LOG")
-                .font(FoundryTheme.Fonts.azeretMono(9))
-                .tracking(2.7)
-                .foregroundStyle(FoundryTheme.Colors.textMuted)
-
             ScrollView {
-                Text(message)
-                    .font(FoundryTheme.Fonts.azeretMono(11))
-                    .foregroundStyle(FoundryTheme.Colors.trafficRed.opacity(0.85))
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .textSelection(.enabled)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(FoundryTheme.Spacing.lg)
-            }
-            .frame(maxHeight: 200)
-            .background(FoundryTheme.Colors.backgroundDeep)
-            .foundryBorder()
-        }
-    }
+                VStack(alignment: .leading, spacing: 24) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(failureTitle)
+                            .font(.title)
+                            .fontWeight(.bold)
 
-    // MARK: - Action Bar
+                        Text(failureSubtitle)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
 
-    private var actionBar: some View {
-        HStack(spacing: 0) {
-            errorAction(label: "LIBRARY", icon: "square.grid.2x2") {
-                appState.popToRoot()
-            }
-            Rectangle().fill(FoundryTheme.Colors.border).frame(width: 1)
-            errorAction(label: "EDIT PROMPT", icon: "pencil") {
-                appState.popToRoot()
-                Task {
-                    try? await Task.sleep(for: .milliseconds(100))
-                    appState.push(.prompt)
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Error Log")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+
+                        ScrollView {
+                            Text(message)
+                                .font(.system(.body, design: .monospaced))
+                                .foregroundStyle(.red)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .textSelection(.enabled)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .padding(12)
+                        }
+                        .frame(maxHeight: 200)
+                        .background(Color(.controlBackgroundColor).opacity(0.5), in: .rect(cornerRadius: 6))
+                    }
                 }
+                .frame(maxWidth: 600)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(24)
             }
-            Rectangle().fill(FoundryTheme.Colors.border).frame(width: 1)
-            errorAction(label: "RETRY", icon: "arrow.counterclockwise") {
-                appState.push(.generation(config: config))
-            }
-        }
-        .frame(height: 64)
-        .background(FoundryTheme.Colors.backgroundToolbar)
-        .overlay(alignment: .top) {
-            Rectangle().fill(FoundryTheme.Colors.border).frame(height: 1)
-        }
-    }
 
-    private func errorAction(label: String, icon: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            VStack(spacing: 5) {
-                Image(systemName: icon)
-                    .font(.system(size: 11, weight: .light))
-                    .foregroundStyle(FoundryTheme.Colors.textSecondary)
-                Text(label)
-                    .font(FoundryTheme.Fonts.azeretMono(8))
-                    .tracking(1.2)
-                    .foregroundStyle(FoundryTheme.Colors.textMuted)
+            HStack(spacing: 12) {
+                Button {
+                    appState.popToRoot()
+                } label: {
+                    Label("Library", systemImage: "square.grid.2x2")
+                }
+
+                Button {
+                    appState.popToRoot()
+                    Task {
+                        try? await Task.sleep(for: .milliseconds(100))
+                        appState.push(.prompt)
+                    }
+                } label: {
+                    Label("Edit Prompt", systemImage: "pencil")
+                }
+
+                Button("Retry") {
+                    appState.push(.generation(config: config))
+                }
+                .buttonStyle(.borderedProminent)
             }
+            .padding(16)
             .frame(maxWidth: .infinity)
-            .frame(height: 64)
-            .contentShape(Rectangle())
+            .background(.bar)
         }
-        .buttonStyle(.plain)
+        .navigationTitle("Build Failed")
+        .navigationBarBackButtonHidden(true)
     }
 }
 
 #Preview {
     NavigationStack {
         ErrorView(
-            message: "Code generation failed: Generation finished but the plugin implementation is incomplete:\n– no parameters defined in createParameterLayout()\n– editor has fewer than 2 visible controls — the UI is essentially empty",
+            message: "Code generation failed: Generation finished but the plugin implementation is incomplete:\n– no parameters defined in createParameterLayout()\n– editor has fewer than 2 visible controls",
             config: GenerationConfig(prompt: "A warm analog synth")
         )
     }

--- a/Foundry/Views/GenerationProgressView.swift
+++ b/Foundry/Views/GenerationProgressView.swift
@@ -53,15 +53,44 @@ struct GenerationProgressView: View {
     @State private var completedSteps: Set<Int> = []
     @State private var highWaterStep: Int = 0
 
+    @State private var showConsole = false
+
     var body: some View {
-        VStack(spacing: 0) {
-            WindowChromeBar(title: "FOUNDRY CORE V1.0.4")
-            topNav
-            mainContent
+        HStack(spacing: 0) {
+            leftPanel
+                .frame(maxWidth: .infinity)
+
+            if showConsole {
+                Divider()
+
+                TerminalView(
+                    title: "Build Log",
+                    logLines: pipeline.logLines,
+                    elapsedTime: formattedTime,
+                    streamingText: pipeline.streamingText
+                )
+                .frame(maxWidth: .infinity)
+            }
         }
-        .background(FoundryTheme.Colors.background)
+        .navigationTitle("Building")
         .navigationBarBackButtonHidden(true)
-        .toolbar(.hidden)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") {
+                    pipeline.cancel()
+                    appState.popToRoot()
+                }
+            }
+            ToolbarItem(placement: .automatic) {
+                Toggle(isOn: Binding(
+                    get: { showConsole },
+                    set: { newValue in withAnimation { showConsole = newValue } }
+                )) {
+                    Label("Console", systemImage: "terminal")
+                }
+                .toggleStyle(.button)
+            }
+        }
         .onAppear {
             pipeline.run(config: config, appState: appState)
             appState.buildProgress = 0
@@ -77,81 +106,10 @@ struct GenerationProgressView: View {
         }
         .onChange(of: pipeline.currentStep) { oldValue, newValue in
             if newValue.rawValue > highWaterStep {
-                // Only mark steps complete and advance progress when moving forward
                 highWaterStep = newValue.rawValue
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    _ = completedSteps.insert(oldValue.rawValue)
-                }
+                _ = completedSteps.insert(oldValue.rawValue)
             }
             appState.buildProgress = progress
-        }
-    }
-
-    // MARK: - Top Nav
-
-    private var topNav: some View {
-        HStack {
-            HStack(spacing: FoundryTheme.Spacing.xxl) {
-                Text("FOUNDRY")
-                    .font(FoundryTheme.Fonts.spaceGrotesk(20))
-                    .tracking(1)
-                    .foregroundStyle(.white)
-
-                HStack(spacing: FoundryTheme.Spacing.xl) {
-                    ForEach(PluginFilter.allCases, id: \.self) { tab in
-                        Text(tab.rawValue)
-                            .font(FoundryTheme.Fonts.jetBrainsMono(11, weight: .medium))
-                            .tracking(1.1)
-                            .foregroundStyle(FoundryTheme.Colors.textMuted)
-                    }
-                }
-            }
-
-            Spacer()
-
-            HStack(spacing: FoundryTheme.Spacing.md) {
-                Text("BUILDING · \(Int(progress * 100))%")
-                    .font(FoundryTheme.Fonts.jetBrainsMono(11))
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 13)
-                    .padding(.vertical, 5)
-                    .foundryBorder(background: FoundryTheme.Colors.backgroundSubtle, border: Color.white.opacity(0.1))
-
-                FoundryActionButton(title: "NEW") {
-                    pipeline.cancel()
-                    appState.popToRoot()
-                }
-            }
-        }
-        .padding(.horizontal, FoundryTheme.Spacing.xl)
-        .frame(height: FoundryTheme.Layout.headerHeight)
-        .background(FoundryTheme.Colors.background)
-    }
-
-    // MARK: - Main Content
-
-    private var mainContent: some View {
-        GeometryReader { geo in
-            HStack(spacing: 0) {
-                leftPanel
-                    .frame(maxWidth: .infinity)
-                    .overlay(alignment: .trailing) {
-                        Rectangle().fill(Color.white.opacity(0.05)).frame(width: 1)
-                    }
-
-                TerminalView(
-                    title: "CONVERGENCE_LOG_V1.0.4.SH",
-                    logLines: pipeline.logLines,
-                    elapsedTime: formattedTime,
-                    streamingText: pipeline.streamingText
-                )
-                .frame(maxWidth: .infinity)
-            }
-            .frame(height: geo.size.height)
-        }
-        .background(FoundryTheme.Colors.background)
-        .overlay(alignment: .top) {
-            Rectangle().fill(Color.white.opacity(0.05)).frame(height: 1)
         }
     }
 
@@ -159,53 +117,24 @@ struct GenerationProgressView: View {
 
     private var leftPanel: some View {
         VStack(spacing: 0) {
-            radialArc
-                .padding(.bottom, FoundryTheme.Spacing.xxl)
+            Spacer()
 
-            GenerationStepList(
-                currentStep: pipeline.currentStep,
-                completedSteps: completedSteps
-            )
-        }
-        .frame(maxWidth: 448)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-        .padding(.horizontal, FoundryTheme.Spacing.xxl)
-    }
+            VStack(spacing: 24) {
+                GenerationStepList(
+                    currentStep: pipeline.currentStep,
+                    completedSteps: completedSteps
+                )
+                .frame(maxWidth: 360)
 
-    // MARK: - Radial Arc
-
-    private var radialArc: some View {
-        ZStack(alignment: .bottom) {
-            ZStack {
-                Circle()
-                    .stroke(Color.white.opacity(0.05), lineWidth: 1)
-                    .frame(width: 320, height: 320)
-
-                SemiArc(progress: progress)
-                    .stroke(Color.white, style: StrokeStyle(lineWidth: 2, lineCap: .round))
-                    .frame(width: 320, height: 320)
+                ProgressView(value: progress)
+                    .tint(.accentColor)
+                    .frame(maxWidth: 360)
             }
-            .frame(width: 320, height: 320)
-            .frame(width: 320, height: 160, alignment: .top)
-            .clipped()
 
-            VStack(spacing: 0) {
-                Text("\(Int(progress * 100))%")
-                    .font(FoundryTheme.Fonts.spaceGrotesk(60))
-                    .tracking(1)
-                    .foregroundStyle(.white)
-                    .monospacedDigit()
-
-                Text("ENGINE CONVERGENCE")
-                    .font(FoundryTheme.Fonts.jetBrainsMono(10))
-                    .tracking(3)
-                    .foregroundStyle(FoundryTheme.Colors.textMuted)
-                    .padding(.top, FoundryTheme.Spacing.xs)
-            }
+            Spacer()
         }
-        .frame(width: 320)
+        .padding(32)
     }
-
 
     // MARK: - Helpers
 
@@ -222,7 +151,6 @@ struct GenerationProgressView: View {
 
 // MARK: - Generation Step List
 
-/// Step list specifically styled for the generation progress panel.
 struct GenerationStepList: View {
     let currentStep: GenerationStep
     let completedSteps: Set<Int>
@@ -235,7 +163,6 @@ struct GenerationStepList: View {
                     isActive: currentStep == step,
                     isDone: completedSteps.contains(step.rawValue)
                 )
-                .padding(.top, step == .preparingProject ? 0 : FoundryTheme.Spacing.md)
             }
         }
     }
@@ -251,77 +178,36 @@ struct GenerationStepRow: View {
     private var isPending: Bool { !isDone && !isActive }
 
     var body: some View {
-        if isActive {
-            activeRow
-        } else {
-            inactiveRow
-        }
-    }
-
-    private var activeRow: some View {
-        HStack {
-            HStack(spacing: FoundryTheme.Spacing.md) {
-                Image(systemName: "arrow.2.circlepath")
-                    .font(.system(size: 10))
-                    .foregroundStyle(.white)
-                    .frame(width: 15)
-
-                Text(step.terminalLabel)
-                    .font(FoundryTheme.Fonts.jetBrainsMono(11, weight: .bold))
-                    .tracking(0.55)
-                    .foregroundStyle(.white)
+        HStack(spacing: 10) {
+            if isDone {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.green)
+                    .frame(width: 20)
+            } else if isActive {
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(width: 20)
+            } else {
+                Image(systemName: "circle")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.quaternary)
+                    .frame(width: 20)
             }
 
-            Spacer()
-
-            HStack(spacing: 6) {
-                ForEach([1.0, 0.4, 0.1], id: \.self) { opacity in
-                    Rectangle()
-                        .fill(Color.white.opacity(opacity))
-                        .frame(width: 4, height: 4)
-                }
-            }
-        }
-        .padding(.leading, 18)
-        .padding(.trailing, FoundryTheme.Spacing.md)
-        .padding(.vertical, FoundryTheme.Spacing.md)
-        .background(FoundryTheme.Colors.backgroundSubtle)
-        .overlay(alignment: .leading) {
-            Rectangle().fill(Color.white).frame(width: 2)
-        }
-    }
-
-    private var inactiveRow: some View {
-        HStack {
-            HStack(spacing: FoundryTheme.Spacing.md) {
-                if isDone {
-                    Image(systemName: "checkmark")
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundStyle(FoundryTheme.Colors.textMuted)
-                        .frame(width: 15)
-                } else {
-                    Circle()
-                        .stroke(FoundryTheme.Colors.textFaint, lineWidth: 1)
-                        .frame(width: 14, height: 14)
-                        .frame(width: 15)
-                }
-
-                Text(step.terminalLabel)
-                    .font(FoundryTheme.Fonts.jetBrainsMono(11))
-                    .tracking(0.55)
-                    .foregroundStyle(FoundryTheme.Colors.textMuted)
-            }
+            Text(step.label)
+                .font(.system(.body, design: .monospaced))
+                .foregroundStyle(isPending ? .tertiary : .primary)
 
             Spacer()
 
             if isDone {
-                Text("DONE")
-                    .font(FoundryTheme.Fonts.jetBrainsMono(10))
-                    .foregroundStyle(FoundryTheme.Colors.textMuted.opacity(0.4))
+                Text("Done")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
-        .padding(.horizontal, FoundryTheme.Spacing.xs)
-        .opacity(isPending ? 0.3 : 1)
+        .padding(.vertical, 6)
     }
 }
 

--- a/Foundry/Views/PluginDetailView.swift
+++ b/Foundry/Views/PluginDetailView.swift
@@ -32,8 +32,6 @@ struct PluginDetailView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            WindowChromeBar(title: "PLUGIN_INFO.SH")
-
             artworkSection
 
             infoSection
@@ -88,7 +86,7 @@ struct PluginDetailView: View {
                 Text(plugin.name.uppercased())
                     .font(FoundryTheme.Fonts.spaceGrotesk(32))
                     .tracking(1)
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.primary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.6)
             }
@@ -135,39 +133,46 @@ struct PluginDetailView: View {
     // MARK: - Actions
 
     private var actionSection: some View {
-        HStack(spacing: 0) {
-            DetailAction(label: "FINDER", icon: "folder") {
-                onAction?(.showInFinder)
-            }
-            VerticalSeparator()
-            DetailAction(label: "RENAME", icon: "pencil") {
-                onAction?(.rename)
-            }
-            VerticalSeparator()
-            DetailAction(label: "REGENERATE", icon: "arrow.counterclockwise") {
-                onAction?(.regenerate)
-            }
-            VerticalSeparator()
-            DetailAction(label: "LOGO", icon: "photo.badge.sparkles", disabled: logoTask != nil) {
-                startLogoGeneration()
-            }
-            VerticalSeparator()
-            DetailAction(label: "LOGS", icon: "doc.text", disabled: plugin.generationLogPath == nil) {
-                if let path = plugin.generationLogPath {
-                    NSWorkspace.shared.open(URL(fileURLWithPath: path))
+        HStack {
+            Menu {
+                Button("Show in Finder", systemImage: "folder") {
+                    onAction?(.showInFinder)
                 }
+                Button("Rename", systemImage: "pencil") {
+                    onAction?(.rename)
+                }
+                Button("Regenerate", systemImage: "arrow.counterclockwise") {
+                    onAction?(.regenerate)
+                }
+                Button("Generate Logo", systemImage: "photo.badge.sparkles") {
+                    startLogoGeneration()
+                }
+                .disabled(logoTask != nil)
+                if plugin.generationLogPath != nil {
+                    Button("View Logs", systemImage: "doc.text") {
+                        if let path = plugin.generationLogPath {
+                            NSWorkspace.shared.open(URL(fileURLWithPath: path))
+                        }
+                    }
+                }
+                Divider()
+                Button("Delete", systemImage: "trash", role: .destructive) {
+                    onAction?(.delete)
+                }
+            } label: {
+                Label("Actions", systemImage: "ellipsis.circle")
             }
-            VerticalSeparator()
-            DetailAction(label: "CLOSE", icon: "xmark") {
+            .menuStyle(.borderlessButton)
+
+            Spacer()
+
+            Button("Done") {
                 dismiss()
             }
-            VerticalSeparator()
-            DetailAction(label: "DELETE", icon: "trash", destructive: true) {
-                onAction?(.delete)
-            }
+            .buttonStyle(.borderedProminent)
+            .keyboardShortcut(.cancelAction)
         }
-        .frame(height: 64)
-        .background(FoundryTheme.Colors.backgroundToolbar)
+        .padding(16)
     }
 
     // MARK: - Helpers
@@ -242,11 +247,11 @@ private struct DetailAction: View {
             VStack(spacing: 5) {
                 Image(systemName: icon)
                     .font(.system(size: 11, weight: .light))
-                    .foregroundStyle(destructive ? Color(hex: 0xFF5F56) : (disabled ? FoundryTheme.Colors.textFaint : FoundryTheme.Colors.textSecondary))
+                    .foregroundStyle(destructive ? Color.red : (disabled ? FoundryTheme.Colors.textFaint : FoundryTheme.Colors.textSecondary))
                 Text(label)
                     .font(FoundryTheme.Fonts.azeretMono(8))
                     .tracking(1.2)
-                    .foregroundStyle(destructive ? Color(hex: 0xFF5F56) : (disabled ? FoundryTheme.Colors.textFaint : FoundryTheme.Colors.textMuted))
+                    .foregroundStyle(destructive ? Color.red : (disabled ? FoundryTheme.Colors.textFaint : FoundryTheme.Colors.textMuted))
             }
             .frame(maxWidth: .infinity)
             .frame(height: 64)
@@ -279,12 +284,12 @@ struct LogoProgressOverlay: View {
 
     var body: some View {
         ZStack {
-            Color.black.opacity(0.7).ignoresSafeArea()
+            Color(.windowBackgroundColor).opacity(0.85).ignoresSafeArea()
 
             VStack(spacing: FoundryTheme.Spacing.md) {
                 ProgressView()
                     .progressViewStyle(.circular)
-                    .tint(.white)
+                    .tint(.primary)
 
                 Text(progress.message.uppercased())
                     .font(FoundryTheme.Fonts.azeretMono(10))

--- a/Foundry/Views/PluginLibraryView.swift
+++ b/Foundry/Views/PluginLibraryView.swift
@@ -25,29 +25,21 @@ struct PluginLibraryView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            FoundryHeaderBar(
-                activeFilter: filter,
-                onFilterTap: { filter = $0 },
-                onLogoTap: {}
-            ) {
-                HStack(spacing: FoundryTheme.Spacing.md) {
-                    FoundryActionButton(title: "+ NEW") {
-                        appState.push(.prompt)
-                    }
-
-                    if let building = appState.plugins.first(where: { $0.status == .building }) {
-                        BuildingIndicator(name: building.name)
-                    }
-                }
-            }
-
+            filterBar
             ScrollView {
                 pluginGrid
             }
-            .background(FoundryTheme.Colors.backgroundElevated)
-
         }
-        .background(FoundryTheme.Colors.backgroundElevated)
+        .navigationTitle("Foundry")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    appState.push(.prompt)
+                } label: {
+                    Label("New Plugin", systemImage: "plus")
+                }
+            }
+        }
         .sheet(item: $selectedPlugin) { plugin in
             PluginDetailView(plugin: plugin) { action in
                 handleDetailAction(action, for: plugin)
@@ -90,6 +82,20 @@ struct PluginLibraryView: View {
         }
     }
 
+    // MARK: - Filter Bar
+
+    private var filterBar: some View {
+        HStack(spacing: 0) {
+            FilterTabBar(activeFilter: filter, onTap: { filter = $0 })
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .background(.bar)
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+    }
+
     // MARK: - Plugin Grid
 
     private var pluginGrid: some View {
@@ -109,7 +115,7 @@ struct PluginLibraryView: View {
                 }
             }
         }
-        .background(FoundryTheme.Colors.backgroundSubtle)
+        .background(FoundryTheme.Colors.border)
     }
 
     // MARK: - Actions
@@ -168,12 +174,12 @@ struct BuildingIndicator: View {
     var body: some View {
         HStack(spacing: FoundryTheme.Spacing.xs) {
             Circle()
-                .fill(Color.white)
+                .fill(Color.accentColor)
                 .frame(width: 6, height: 6)
             Text("BUILDING · \(Int(appState.buildProgress * 100))%")
                 .font(FoundryTheme.Fonts.jetBrainsMono(9))
                 .tracking(0.9)
-                .foregroundStyle(.white)
+                .foregroundStyle(.primary)
         }
     }
 }
@@ -195,15 +201,7 @@ struct NewPluginCard: View {
                     .foregroundStyle(FoundryTheme.Colors.textSecondary)
             }
             .frame(maxWidth: .infinity, minHeight: 340)
-            .background(FoundryTheme.Colors.backgroundCard)
-            .overlay(
-                Rectangle()
-                    .strokeBorder(
-                        FoundryTheme.Colors.borderSubtle,
-                        style: StrokeStyle(lineWidth: 1, dash: [4, 4])
-                    )
-                    .padding(1)
-            )
+            .background(Color(.textBackgroundColor))
         }
         .buttonStyle(.plain)
     }
@@ -241,7 +239,8 @@ struct LibraryPluginCard: View {
     @ViewBuilder
     private var artworkArea: some View {
         ZStack {
-            FoundryTheme.Colors.backgroundCard
+            Color(.textBackgroundColor)
+            plugin.color.opacity(0.07)
             if plugin.status == .building {
                 buildingArtwork
             } else if let img = loadLogoImage() {
@@ -271,29 +270,29 @@ struct LibraryPluginCard: View {
 
     private var infoArea: some View {
         ZStack(alignment: .bottomLeading) {
-            (plugin.status == .building ? Color(hex: 0x1F1F1F) : FoundryTheme.Colors.backgroundToolbar)
+            Color(.windowBackgroundColor)
             VStack(alignment: .leading, spacing: 3) {
                 if plugin.status == .building {
                     Text(plugin.name.uppercased())
                         .font(FoundryTheme.Fonts.spaceGrotesk(20))
                         .tracking(1)
-                        .foregroundStyle(.white.opacity(0.4))
+                        .foregroundStyle(.secondary)
                         .lineLimit(1)
                     Text("BUILDING... \(Int(appState.buildProgress * 100))%")
                         .font(FoundryTheme.Fonts.jetBrainsMono(9))
                         .tracking(1.8)
-                        .foregroundStyle(.white)
+                        .foregroundStyle(.primary)
                 } else {
                     Text(plugin.name.uppercased())
                         .font(FoundryTheme.Fonts.spaceGrotesk(24))
                         .tracking(1)
-                        .foregroundStyle(.white)
+                        .foregroundStyle(.primary)
                         .lineLimit(1)
                 }
                 Text(formatSubtitle())
                     .font(FoundryTheme.Fonts.jetBrainsMono(9))
                     .tracking(0.9)
-                    .foregroundStyle(FoundryTheme.Colors.textSecondary)
+                    .foregroundStyle(.secondary)
                     .textCase(.uppercase)
             }
             .padding(.horizontal, 20)
@@ -304,8 +303,8 @@ struct LibraryPluginCard: View {
                     Spacer()
                     GeometryReader { geo in
                         ZStack(alignment: .leading) {
-                            Color(hex: 0x353535).frame(height: 4)
-                            Color.white.frame(width: geo.size.width * appState.buildProgress, height: 4)
+                            Color(.separatorColor).frame(height: 4)
+                            Color.accentColor.frame(width: geo.size.width * appState.buildProgress, height: 4)
                         }
                     }
                     .frame(height: 4)

--- a/Foundry/Views/PromptView.swift
+++ b/Foundry/Views/PromptView.swift
@@ -5,9 +5,6 @@ import SwiftUI
 struct PromptView: View {
     @Environment(AppState.self) private var appState
     @State private var prompt = ""
-    @State private var format: FormatOption = .both
-    @State private var channelLayout: ChannelLayout = .stereo
-    @State private var presetCount: PresetCount = .five
     @FocusState private var isFocused: Bool
 
     private let suggestions: [SuggestionCategory] = [
@@ -41,42 +38,14 @@ struct PromptView: View {
     ]
 
     var body: some View {
-        VStack(spacing: 0) {
-            FoundryHeaderBar(
-                onLogoTap: { appState.popToRoot() }
-            ) {
-                HStack(spacing: FoundryTheme.Spacing.lg) {
-                    if let building = appState.plugins.first(where: { $0.status == .building }) {
-                        BuildingIndicator(name: building.name)
-                    }
-
-                    FoundryActionButton(
-                        title: "GENERATE",
-                        action: generate,
-                        isDisabled: prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                    )
-                    .keyboardShortcut(.return, modifiers: .command)
-                }
-            }
-
-            GeometryReader { geo in
-                ScrollView {
-                    HStack(spacing: 0) {
-                        Spacer(minLength: 128)
-                        contentCanvas
-                            .frame(maxWidth: 1024)
-                        Spacer(minLength: 128)
-                    }
-                    .frame(minHeight: geo.size.height)
-                    .padding(.vertical, FoundryTheme.Spacing.xxxl)
-                }
-            }
-            .background(FoundryTheme.Colors.background)
-
+        HStack(spacing: 0) {
+            Spacer(minLength: 80)
+            contentCanvas
+                .frame(maxWidth: 1024)
+            Spacer(minLength: 80)
         }
-        .background(FoundryTheme.Colors.background)
-        .navigationBarBackButtonHidden(true)
-        .toolbar(.hidden)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .navigationTitle("New Plugin")
         .onAppear { isFocused = true }
     }
 
@@ -84,183 +53,62 @@ struct PromptView: View {
 
     private var contentCanvas: some View {
         VStack(alignment: .leading, spacing: 0) {
+            Spacer()
+
             promptSection
-                .padding(.bottom, FoundryTheme.Spacing.xxl)
+                .padding(.bottom, 24)
 
             categoryGrid
-                .padding(.bottom, FoundryTheme.Spacing.xxxl)
 
-            Spacer(minLength: 0)
-
-            configRow
+            Spacer()
         }
-        .padding(.horizontal, FoundryTheme.Spacing.xl)
     }
 
     // MARK: - Prompt Section
 
     private var promptSection: some View {
-        VStack(alignment: .leading, spacing: FoundryTheme.Spacing.xs) {
-            Text("Natural Language Prompt")
-                .font(FoundryTheme.Fonts.jetBrainsMono(10))
-                .tracking(1)
-                .foregroundStyle(FoundryTheme.Colors.textSecondary)
-                .textCase(.uppercase)
-
-            promptTextarea
-        }
-    }
-
-    private var promptTextarea: some View {
-        ZStack(alignment: .topLeading) {
-            FoundryTheme.Colors.backgroundDeep
-
-            if prompt.isEmpty {
-                Text("Describe the sound architecture... (e.g., A dual-oscillator subtractive synth with a ladder filter and gritty tape saturation stage)")
-                    .font(FoundryTheme.Fonts.inter(20))
-                    .lineSpacing(8)
-                    .foregroundStyle(FoundryTheme.Colors.borderSubtle.opacity(0.3))
-                    .allowsHitTesting(false)
-                    .padding(FoundryTheme.Spacing.lg)
-            }
-
+        VStack(alignment: .leading, spacing: 0) {
             TextEditor(text: $prompt)
-                .font(FoundryTheme.Fonts.inter(20))
-                .lineSpacing(8)
-                .scrollContentBackground(.hidden)
-                .background(Color.clear)
-                .foregroundStyle(.white)
+                .font(.system(size: 14))
                 .focused($isFocused)
-                .padding(FoundryTheme.Spacing.lg - 5)
+                .frame(height: 100)
+
+            HStack {
+                Spacer()
+                Button("Generate") { generate() }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.regular)
+                    .disabled(prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .keyboardShortcut(.return, modifiers: .command)
+            }
+            .padding(.top, 8)
         }
-        .frame(height: 180)
-        .foundryBorder()
-        .cornerBrackets()
     }
 
     // MARK: - Category Grid
 
     private var categoryGrid: some View {
-        HStack(alignment: .top, spacing: FoundryTheme.Spacing.lg) {
+        HStack(alignment: .top, spacing: 1) {
             ForEach(suggestions) { cat in
                 SuggestionCategoryCard(category: cat) { item in
-                    withAnimation(.easeOut(duration: 0.12)) {
-                        prompt = item.fullPrompt
-                    }
+                    prompt = item.fullPrompt
                 }
             }
         }
-    }
-
-    // MARK: - Config Row
-
-    private var configRow: some View {
-        VStack(spacing: 0) {
+        .background(Color(.separatorColor))
+        .overlay(
             Rectangle()
-                .fill(FoundryTheme.Colors.border)
-                .frame(height: 1)
-
-            HStack(alignment: .center) {
-                HStack(spacing: FoundryTheme.Spacing.xxxl) {
-                    configSelector(
-                        label: "FORMAT",
-                        options: FormatOption.allCases.map { $0.rawValue.uppercased() },
-                        selected: format.rawValue.uppercased()
-                    ) { cycleFormat() }
-
-                    configSelector(
-                        label: "CHANNELS",
-                        options: ChannelLayout.allCases.map { $0.rawValue.uppercased() },
-                        selected: channelLayout.rawValue.uppercased()
-                    ) { cycleChannels() }
-
-                    configSelector(
-                        label: "PRESETS",
-                        options: [PresetCount.zero, .five, .ten].map { "\($0.rawValue)" },
-                        selected: "\(presetCount.rawValue)"
-                    ) { cyclePresets() }
-                }
-
-                Spacer()
-
-                Button { appState.push(.quickOptions(prompt: prompt)) } label: {
-                    HStack(spacing: FoundryTheme.Spacing.md) {
-                        Text("Adv. Options")
-                            .font(FoundryTheme.Fonts.jetBrainsMono(10))
-                            .tracking(1)
-                            .foregroundStyle(FoundryTheme.Colors.textSecondary)
-                            .textCase(.uppercase)
-
-                        Image(systemName: "chevron.down")
-                            .font(.system(size: 7))
-                            .foregroundStyle(FoundryTheme.Colors.textSecondary)
-                    }
-                    .padding(.horizontal, 21)
-                    .padding(.vertical, 11)
-                    .foundryBorder(background: FoundryTheme.Colors.backgroundToolbar)
-                }
-                .buttonStyle(.plain)
-            }
-            .padding(.top, FoundryTheme.Spacing.xl)
-            .padding(.bottom, FoundryTheme.Spacing.xxl)
-        }
-    }
-
-    private func configSelector(
-        label: String,
-        options: [String],
-        selected: String,
-        action: @escaping () -> Void
-    ) -> some View {
-        VStack(alignment: .leading, spacing: FoundryTheme.Spacing.xs) {
-            Text(label)
-                .font(FoundryTheme.Fonts.jetBrainsMono(9))
-                .tracking(2.7)
-                .foregroundStyle(FoundryTheme.Colors.textSecondary)
-
-            Button(action: action) {
-                HStack(spacing: 4) {
-                    ForEach(Array(options.enumerated()), id: \.offset) { idx, option in
-                        if idx > 0 {
-                            Text("/")
-                                .font(FoundryTheme.Fonts.jetBrainsMono(12))
-                                .foregroundStyle(FoundryTheme.Colors.textDimmed)
-                        }
-                        Text(option)
-                            .font(FoundryTheme.Fonts.jetBrainsMono(12))
-                            .foregroundStyle(option == selected ? .white : FoundryTheme.Colors.textDimmed)
-                    }
-                }
-            }
-            .buttonStyle(.plain)
-        }
-    }
-
-    // MARK: - Cycle Actions
-
-    private func cycleFormat() {
-        let cases = FormatOption.allCases
-        let idx = cases.firstIndex(of: format)!
-        format = cases[(idx + 1) % cases.count]
-    }
-
-    private func cycleChannels() {
-        channelLayout = channelLayout == .mono ? .stereo : .mono
-    }
-
-    private func cyclePresets() {
-        let cases = PresetCount.allCases
-        let idx = cases.firstIndex(of: presetCount)!
-        presetCount = cases[(idx + 1) % cases.count]
+                .strokeBorder(Color(.separatorColor), lineWidth: 1)
+        )
     }
 
     private func generate() {
         guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         appState.push(.generation(config: GenerationConfig(
             prompt: prompt,
-            format: format,
-            channelLayout: channelLayout,
-            presetCount: presetCount
+            format: .both,
+            channelLayout: .stereo,
+            presetCount: .five
         )))
     }
 }
@@ -276,13 +124,13 @@ struct SuggestionCategoryCard: View {
             HStack(spacing: FoundryTheme.Spacing.sm) {
                 Image(systemName: category.systemImage)
                     .font(.system(size: 11, weight: .regular))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.primary)
                     .frame(width: 14, height: 14)
 
                 Text(category.title)
                     .font(FoundryTheme.Fonts.azeretMono(12))
                     .tracking(2.4)
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.primary)
                     .textCase(.uppercase)
             }
 
@@ -304,9 +152,9 @@ struct SuggestionCategoryCard: View {
                 }
             }
         }
-        .padding(25)
+        .padding(20)
         .frame(maxWidth: .infinity, alignment: .topLeading)
-        .foundryBorder()
+        .background(Color(.textBackgroundColor))
     }
 }
 

--- a/Foundry/Views/RefineProgressView.swift
+++ b/Foundry/Views/RefineProgressView.swift
@@ -83,9 +83,7 @@ struct RefineProgressView: View {
         }
         .onChange(of: pipeline.currentStep) { oldValue, newValue in
             if newValue.rawValue > oldValue.rawValue {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    _ = completedSteps.insert(oldValue.rawValue)
-                }
+                _ = completedSteps.insert(oldValue.rawValue)
             }
         }
     }

--- a/Foundry/Views/ResultView.swift
+++ b/Foundry/Views/ResultView.swift
@@ -6,57 +6,6 @@ struct ResultView: View {
     let plugin: Plugin
 
     var body: some View {
-        VStack(spacing: 0) {
-            WindowChromeBar(title: "BUILD_COMPLETE.SH")
-            topNav
-            mainContent
-            actionBar
-        }
-        .background(FoundryTheme.Colors.background)
-        .navigationBarBackButtonHidden(true)
-        .toolbar(.hidden)
-    }
-
-    // MARK: - Top Nav
-
-    private var topNav: some View {
-        HStack {
-            Text("FOUNDRY")
-                .font(FoundryTheme.Fonts.spaceGrotesk(20))
-                .tracking(1)
-                .foregroundStyle(.white)
-
-            Spacer()
-
-            HStack(spacing: FoundryTheme.Spacing.xs) {
-                Circle()
-                    .fill(FoundryTheme.Colors.trafficGreen)
-                    .frame(width: 6, height: 6)
-                Text("BUILD SUCCESSFUL")
-                    .font(FoundryTheme.Fonts.azeretMono(11))
-                    .tracking(0.9)
-                    .foregroundStyle(FoundryTheme.Colors.trafficGreen)
-            }
-            .padding(.horizontal, 13)
-            .padding(.vertical, 5)
-            .foundryBorder(background: FoundryTheme.Colors.backgroundSubtle, border: Color.white.opacity(0.1))
-
-            FoundryActionButton(title: "DONE") {
-                appState.popToRoot()
-            }
-            .keyboardShortcut(.return, modifiers: .command)
-        }
-        .padding(.horizontal, FoundryTheme.Spacing.xl)
-        .frame(height: FoundryTheme.Layout.headerHeight)
-        .background(FoundryTheme.Colors.background)
-        .overlay(alignment: .bottom) {
-            Rectangle().fill(FoundryTheme.Colors.border).frame(height: 1)
-        }
-    }
-
-    // MARK: - Main Content
-
-    private var mainContent: some View {
         ScrollView {
             VStack(spacing: 0) {
                 artworkSection
@@ -66,7 +15,31 @@ struct ResultView: View {
             .frame(maxWidth: 680)
             .frame(maxWidth: .infinity)
         }
-        .background(FoundryTheme.Colors.backgroundElevated)
+        .navigationTitle(plugin.name)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    openPluginFolder()
+                } label: {
+                    Label("Show in Finder", systemImage: "folder")
+                }
+            }
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    appState.push(.refine(plugin: plugin))
+                } label: {
+                    Label("Refine", systemImage: "slider.horizontal.below.rectangle")
+                }
+                .disabled(plugin.buildDirectory == nil)
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Button("Done") {
+                    appState.popToRoot()
+                }
+                .keyboardShortcut(.return, modifiers: .command)
+            }
+        }
     }
 
     // MARK: - Artwork
@@ -74,7 +47,7 @@ struct ResultView: View {
     private var artworkSection: some View {
         ZStack(alignment: .bottomLeading) {
             ZStack {
-                FoundryTheme.Colors.backgroundCard
+                Color(.controlBackgroundColor)
                 if let img = loadLogoImage() {
                     Image(nsImage: img)
                         .resizable()
@@ -86,15 +59,13 @@ struct ResultView: View {
             }
 
             VStack(alignment: .leading, spacing: 3) {
-                Text(plugin.type.displayName.uppercased() + " · " + plugin.formats.map(\.rawValue).joined(separator: " / "))
-                    .font(FoundryTheme.Fonts.azeretMono(9))
-                    .tracking(1.2)
-                    .foregroundStyle(FoundryTheme.Colors.textSecondary)
+                Text("\(plugin.type.displayName) · \(plugin.formats.map(\.rawValue).joined(separator: " / "))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
 
-                Text(plugin.name.uppercased())
-                    .font(FoundryTheme.Fonts.spaceGrotesk(40))
-                    .tracking(1)
-                    .foregroundStyle(.white)
+                Text(plugin.name)
+                    .font(.title)
+                    .fontWeight(.bold)
                     .lineLimit(1)
                     .minimumScaleFactor(0.6)
             }
@@ -103,79 +74,33 @@ struct ResultView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 LinearGradient(
-                    colors: [.clear, FoundryTheme.Colors.backgroundCard],
+                    colors: [.clear, Color(.windowBackgroundColor)],
                     startPoint: .top,
                     endPoint: .bottom
                 )
             )
         }
         .clipped()
-        .overlay(alignment: .bottom) {
-            Rectangle().fill(FoundryTheme.Colors.border).frame(height: 1)
-        }
     }
 
     // MARK: - Info
 
     private var infoSection: some View {
         VStack(spacing: 0) {
-            ResultInfoRow(label: "PROMPT", value: plugin.prompt)
-            Rectangle().fill(FoundryTheme.Colors.border).frame(height: 1)
-            ResultInfoRow(label: "TYPE", value: plugin.type.displayName.uppercased())
-            Rectangle().fill(FoundryTheme.Colors.border).frame(height: 1)
-            ResultInfoRow(label: "FORMATS", value: plugin.formats.map(\.rawValue).joined(separator: " / "))
+            ResultInfoRow(label: "Prompt", value: plugin.prompt)
+            Divider()
+            ResultInfoRow(label: "Type", value: plugin.type.displayName)
+            Divider()
+            ResultInfoRow(label: "Formats", value: plugin.formats.map(\.rawValue).joined(separator: " / "))
             if let au = plugin.installPaths.au {
-                Rectangle().fill(FoundryTheme.Colors.border).frame(height: 1)
-                ResultInfoRow(label: "AU PATH", value: au)
+                Divider()
+                ResultInfoRow(label: "AU Path", value: au)
             }
             if let vst3 = plugin.installPaths.vst3 {
-                Rectangle().fill(FoundryTheme.Colors.border).frame(height: 1)
-                ResultInfoRow(label: "VST3 PATH", value: vst3)
+                Divider()
+                ResultInfoRow(label: "VST3 Path", value: vst3)
             }
         }
-        .background(FoundryTheme.Colors.backgroundCard)
-    }
-
-    // MARK: - Action Bar
-
-    private var actionBar: some View {
-        HStack(spacing: 0) {
-            resultAction(label: "LIBRARY", icon: "square.grid.2x2") {
-                appState.popToRoot()
-            }
-            Rectangle().fill(FoundryTheme.Colors.border).frame(width: 1)
-            resultAction(label: "FINDER", icon: "folder") {
-                openPluginFolder()
-            }
-            Rectangle().fill(FoundryTheme.Colors.border).frame(width: 1)
-            resultAction(label: "REFINE", icon: "slider.horizontal.below.rectangle", disabled: plugin.buildDirectory == nil) {
-                appState.push(.refine(plugin: plugin))
-            }
-        }
-        .frame(height: 64)
-        .background(FoundryTheme.Colors.backgroundToolbar)
-        .overlay(alignment: .top) {
-            Rectangle().fill(FoundryTheme.Colors.border).frame(height: 1)
-        }
-    }
-
-    private func resultAction(label: String, icon: String, disabled: Bool = false, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            VStack(spacing: 5) {
-                Image(systemName: icon)
-                    .font(.system(size: 11, weight: .light))
-                    .foregroundStyle(disabled ? FoundryTheme.Colors.textFaint : FoundryTheme.Colors.textSecondary)
-                Text(label)
-                    .font(FoundryTheme.Fonts.azeretMono(8))
-                    .tracking(1.2)
-                    .foregroundStyle(disabled ? FoundryTheme.Colors.textFaint : FoundryTheme.Colors.textMuted)
-            }
-            .frame(maxWidth: .infinity)
-            .frame(height: 64)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .disabled(disabled)
     }
 
     // MARK: - Helpers
@@ -204,16 +129,15 @@ private struct ResultInfoRow: View {
     let value: String
 
     var body: some View {
-        HStack(alignment: .top, spacing: FoundryTheme.Spacing.lg) {
+        HStack(alignment: .top, spacing: 16) {
             Text(label)
-                .font(FoundryTheme.Fonts.azeretMono(9))
-                .tracking(1.2)
-                .foregroundStyle(FoundryTheme.Colors.textMuted)
+                .font(.caption)
+                .foregroundStyle(.tertiary)
                 .frame(width: 72, alignment: .leading)
 
             Text(value)
-                .font(FoundryTheme.Fonts.azeretMono(11))
-                .foregroundStyle(FoundryTheme.Colors.textSecondary)
+                .font(.system(.body, design: .monospaced))
+                .foregroundStyle(.secondary)
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Foundry/Views/WelcomeView.swift
+++ b/Foundry/Views/WelcomeView.swift
@@ -4,187 +4,43 @@ struct WelcomeView: View {
     @Environment(AppState.self) private var appState
 
     var body: some View {
-        VStack(spacing: 0) {
-            welcomeHeader
+        VStack(spacing: 20) {
             Spacer()
-            mainContent
-            Spacer()
-            welcomeFooter
-        }
-        .background(FoundryTheme.Colors.background)
-        .navigationBarBackButtonHidden(true)
-        .toolbar(.hidden)
-    }
 
-    // MARK: - Header
+            Image(systemName: "waveform.badge.plus")
+                .font(.system(size: 48, weight: .thin))
+                .foregroundStyle(.secondary)
 
-    private var welcomeHeader: some View {
-        WindowChromeBar(title: "FOUNDRY", height: 48)
-    }
+            VStack(spacing: 6) {
+                Text("Welcome to Foundry")
+                    .font(.title2)
+                    .fontWeight(.medium)
 
-    // MARK: - Main Content
+                Text("Generate real, compilable audio plugins\nfrom a natural language description.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
 
-    private var mainContent: some View {
-        VStack(spacing: 0) {
-            Text("THIS IS WHAT FOUNDRY BUILDS.")
-                .font(FoundryTheme.Fonts.azeretMono(10))
-                .tracking(4)
-                .foregroundStyle(Color(hex: 0x71717A))
-                .textCase(.uppercase)
-                .padding(.bottom, 40)
-
-            pluginShowcaseCard
-                .frame(width: 800, height: 214)
-
-            Text("Generated from: shimmer reverb with pitch-shifted tails and freeze")
-                .font(FoundryTheme.Fonts.jetBrainsMono(11))
-                .foregroundStyle(Color(hex: 0x52525B))
-                .padding(.top, FoundryTheme.Spacing.xl)
-
-            FoundryActionButton(title: "BUILD YOUR FIRST PLUGIN →") {
+            Button("Build Your First Plugin") {
                 appState.push(.prompt)
             }
-            .padding(.top, FoundryTheme.Spacing.xxxl)
-        }
-        .padding(.horizontal, FoundryTheme.Spacing.xl)
-        .padding(.vertical, 118)
-    }
-
-    // MARK: - Plugin Showcase Card
-
-    private var pluginShowcaseCard: some View {
-        HStack(spacing: 0) {
-            artworkSection
-                .frame(width: 480)
-            metadataSection
-                .frame(width: 320)
-        }
-    }
-
-    private var artworkSection: some View {
-        ZStack {
-            Color(hex: 0x18181B)
-
-            Canvas { ctx, size in
-                let center = CGPoint(x: size.width / 2, y: size.height / 2)
-                let radii: [(CGFloat, CGFloat)] = [
-                    (300, 0.04), (260, 0.04), (220, 0.05),
-                    (180, 0.06), (140, 0.07), (100, 0.08),
-                    (60, 0.1), (30, 0.12),
-                ]
-                for (r, opacity) in radii {
-                    let rect = CGRect(x: center.x - r, y: center.y - r, width: r * 2, height: r * 2)
-                    ctx.stroke(
-                        Path(ellipseIn: rect),
-                        with: .color(Color.white.opacity(opacity)),
-                        lineWidth: 1
-                    )
-                }
-            }
-            .opacity(0.2)
-
-            ZStack {
-                Circle().stroke(Color.white.opacity(0.2), lineWidth: 1).frame(width: 192, height: 192)
-                Circle().stroke(Color.white.opacity(0.4), lineWidth: 1).frame(width: 160, height: 160)
-                Circle().stroke(Color.white.opacity(0.6), lineWidth: 1).frame(width: 128, height: 128)
-                Circle().fill(Color.white).frame(width: 16, height: 16)
-            }
-        }
-        .clipped()
-    }
-
-    private var metadataSection: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            VStack(alignment: .leading, spacing: FoundryTheme.Spacing.xxs) {
-                Text("EFFECT · VST3 / AU")
-                    .font(FoundryTheme.Fonts.jetBrainsMono(10))
-                    .tracking(1)
-                    .foregroundStyle(Color(hex: 0x71717A))
-                    .textCase(.uppercase)
-
-                Text("NEURAL_REVERB")
-                    .font(FoundryTheme.Fonts.spaceGrotesk(36))
-                    .tracking(1)
-                    .foregroundStyle(.white)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.6)
-            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .keyboardShortcut(.return, modifiers: .command)
+            .padding(.top, 8)
 
             Spacer()
-
-            VStack(alignment: .leading, spacing: FoundryTheme.Spacing.lg) {
-                Rectangle()
-                    .fill(Color.white.opacity(0.1))
-                    .frame(height: 1)
-
-                HStack(alignment: .top, spacing: FoundryTheme.Spacing.md) {
-                    MetaAttribute(label: "Algorithm", value: "PITCH_SHIFT_FREEZE")
-                    MetaAttribute(label: "Architecture", value: "NEURAL_NET_V2")
-                }
-            }
         }
-        .padding(.leading, 49)
-        .padding(.trailing, FoundryTheme.Spacing.xxl)
-        .padding(.vertical, FoundryTheme.Spacing.xxl)
-        .background(Color(hex: 0x09090B))
-        .overlay(alignment: .leading) {
-            Rectangle().fill(Color.white.opacity(0.05)).frame(width: 1)
-        }
-    }
-
-    // MARK: - Footer
-
-    private var welcomeFooter: some View {
-        HStack {
-            Text("© 2026 FOUNDRY SYSTEMS")
-                .font(FoundryTheme.Fonts.jetBrainsMono(9))
-                .tracking(0.9)
-                .foregroundStyle(Color(hex: 0x3F3F46))
-
-            Spacer()
-
-            Text("SYST_OK // READY")
-                .font(FoundryTheme.Fonts.jetBrainsMono(9))
-                .tracking(0.9)
-                .foregroundStyle(Color(hex: 0x3F3F46))
-                .textCase(.uppercase)
-        }
-        .padding(.horizontal, FoundryTheme.Spacing.xl)
-        .padding(.vertical, FoundryTheme.Spacing.lg)
-        .overlay(alignment: .top) {
-            Rectangle().fill(Color.white.opacity(0.05)).frame(height: 1)
-        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .navigationTitle("Foundry")
     }
 }
-
-// MARK: - Meta Attribute
-
-/// Label/value pair used in metadata sections.
-struct MetaAttribute: View {
-    let label: String
-    let value: String
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: FoundryTheme.Spacing.xxs) {
-            Text(label)
-                .font(FoundryTheme.Fonts.jetBrainsMono(9))
-                .foregroundStyle(Color(hex: 0x52525B))
-                .textCase(.uppercase)
-
-            Text(value)
-                .font(FoundryTheme.Fonts.jetBrainsMono(11))
-                .foregroundStyle(Color(hex: 0xD4D4D8))
-                .textCase(.uppercase)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-}
-
-// MARK: - Preview
 
 #Preview {
-    WelcomeView()
-        .environment(AppState())
-        .preferredColorScheme(.dark)
-        .frame(width: 1024, height: 768)
+    NavigationStack {
+        WelcomeView()
+    }
+    .environment(AppState())
+    .preferredColorScheme(.dark)
 }


### PR DESCRIPTION
## Summary
- **Remove WindowChromeBar** and all custom headers — use native macOS `.navigationTitle()` and `.toolbar {}` across all views
- **System-adaptive colors** — replace all hardcoded hex/dark-mode colors in `FoundryTheme` with `NSColor` bridging (`windowBackgroundColor`, `labelColor`, `separatorColor`, etc.) for proper light/dark mode support
- **Native controls** — use native `TextEditor` for prompt input, `Menu` for plugin detail actions, `Toggle` for console visibility
- **Remove AI slop** — delete fake metrics, over-designed progress indicators (SemiArc), concentric circles showcase, artificial delays in dependency checks, unnecessary animations
- **Clean up views** — remove footer/action bars (ResultView, ErrorView), move actions to native toolbar, remove "Build Succeeded" indicator, remove timer from generation header
- **TerminalView** — add copy logs / export as .txt options via menu

## Test plan
- [ ] Verify all views render correctly in both light and dark mode
- [ ] Check navigation flow: Welcome → Prompt → Generation → Result → Library
- [ ] Verify plugin detail sheet opens with Menu actions working
- [ ] Test console toggle in GenerationProgressView
- [ ] Confirm window is freely resizable with min size 900×620

🤖 Generated with [Claude Code](https://claude.com/claude-code)