### PR TITLE
feat: background builds with build queue page

### DIFF
--- a/Foundry.xcodeproj/project.pbxproj
+++ b/Foundry.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		6D6AEFE51B6FDC1DFB20C16F /* GenerationPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C1774C2EE1F0C15BF39B1E7 /* GenerationPipeline.swift */; };
 		7256639E17819BF99D5BAA78 /* DependencyListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B757385330BAAD1CC592BB96 /* DependencyListModel.swift */; };
 		8502215EAB71ADC5A00BED70 /* ResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4CE5638194D3E319878858 /* ResultView.swift */; };
+		3644C7D01E89D3AA4153B08B /* BuildQueueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8641B562F8D0835FC1CE114 /* BuildQueueView.swift */; };
 		86791B8E09C59944FF09FDE1 /* BuildLoopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4FA286AB0BFE6410D00E84 /* BuildLoopTests.swift */; };
 		86DC86F9E65EB121BAAA6E4B /* PromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB69D6CB5EE2903F1755F2BD /* PromptView.swift */; };
 		8F62055B3F66E39E34698C84 /* Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C806DCDABFBFF5C60F776E68 /* Plugin.swift */; };
@@ -99,6 +100,7 @@
 		B7B720FD5B7CCC0031786F1D /* RefineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefineView.swift; sourceTree = "<group>"; };
 		BAA4AA1400D0A8005F16FC9D /* ClaudeCodeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeCodeService.swift; sourceTree = "<group>"; };
 		BB4CE5638194D3E319878858 /* ResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultView.swift; sourceTree = "<group>"; };
+		E8641B562F8D0835FC1CE114 /* BuildQueueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildQueueView.swift; sourceTree = "<group>"; };
 		BB69D6CB5EE2903F1755F2BD /* PromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptView.swift; sourceTree = "<group>"; };
 		C3EE70BE829D987076CBC625 /* PluginDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDetailView.swift; sourceTree = "<group>"; };
 		C3FB52A3FEB7D539EBDFF7FD /* ProjectAssembler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectAssembler.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				FD87798E4D6622F313640CB5 /* RefineProgressView.swift */,
 				B7B720FD5B7CCC0031786F1D /* RefineView.swift */,
 				BB4CE5638194D3E319878858 /* ResultView.swift */,
+				E8641B562F8D0835FC1CE114 /* BuildQueueView.swift */,
 				F75004640D40807A6FE43589 /* SettingsView.swift */,
 				11F0B8ACE372F6DC5016FB8C /* SetupView.swift */,
 			);
@@ -391,6 +394,7 @@
 				090AF414F35582CB7DBA8CA3 /* RefineProgressView.swift in Sources */,
 				07CDA240F28CA4F534693A2A /* RefineView.swift in Sources */,
 				8502215EAB71ADC5A00BED70 /* ResultView.swift in Sources */,
+				3644C7D01E89D3AA4153B08B /* BuildQueueView.swift in Sources */,
 				AF2D89AC5EED252B56D3D793 /* SettingsView.swift in Sources */,
 				46F97EDD013A980C36506FC2 /* SetupView.swift in Sources */,
 				1DB09B2440A1B060E3CABF0C /* StepListView.swift in Sources */,

--- a/Foundry/App/ContentView.swift
+++ b/Foundry/App/ContentView.swift
@@ -15,29 +15,25 @@ struct ContentView: View {
                 }
             }
             .navigationDestination(for: Route.self) { route in
-                    switch route {
-                    case .prompt:
-                        PromptView()
-
-                    case .quickOptions(let prompt):
-                        QuickOptionsView(prompt: prompt)
-
-                    case .generation(let config):
-                        GenerationProgressView(config: config)
-
-                    case .refinement(let config):
-                        RefineProgressView(config: config)
-
-                    case .refine(let plugin):
-                        RefineView(plugin: plugin)
-
-                    case .result(let plugin):
-                        ResultView(plugin: plugin)
-
-                    case .error(let message, let config):
-                        ErrorView(message: message, config: config)
-                    }
+                switch route {
+                case .prompt:
+                    PromptView()
+                case .quickOptions(let prompt):
+                    QuickOptionsView(prompt: prompt)
+                case .generation(let config):
+                    GenerationProgressView(config: config)
+                case .refinement(let config):
+                    RefineProgressView(config: config)
+                case .refine(let plugin):
+                    RefineView(plugin: plugin)
+                case .result(let plugin):
+                    ResultView(plugin: plugin)
+                case .error(let message, let config):
+                    ErrorView(message: message, config: config)
+                case .queue:
+                    BuildQueueView()
                 }
+            }
         }
         .sheet(isPresented: $state.showSetup) {
             SetupView()

--- a/Foundry/Models/AppState.swift
+++ b/Foundry/Models/AppState.swift
@@ -25,6 +25,7 @@ enum Route: Hashable {
     case refine(plugin: Plugin)
     case result(plugin: Plugin)
     case error(message: String, config: GenerationConfig)
+    case queue
 }
 
 // MARK: - Generation config
@@ -68,6 +69,82 @@ enum PresetCount: Int, CaseIterable, Hashable {
     }
 }
 
+// MARK: - Active Build
+
+/// Tracks an in-progress generation or refinement so the user can navigate away and return.
+@Observable
+@MainActor
+final class ActiveBuild {
+    enum Kind {
+        case generation(GenerationConfig)
+        case refinement(RefineConfig)
+    }
+
+    let kind: Kind
+    let pipeline = GenerationPipeline()
+    var elapsedSeconds: Int = 0
+    var completedSteps: Set<Int> = []
+    var highWaterStep: Int = 0
+    var showConsole: Bool = false
+    /// Set to true while the generation/refine progress view is visible.
+    var isViewingProgress: Bool = false
+    private var timerTask: Task<Void, Never>?
+
+    var displayName: String {
+        switch kind {
+        case .generation(let config):
+            String(config.prompt.prefix(40))
+        case .refinement(let config):
+            config.plugin.name
+        }
+    }
+
+    var route: Route {
+        switch kind {
+        case .generation(let config): .generation(config: config)
+        case .refinement(let config): .refinement(config: config)
+        }
+    }
+
+    var progress: Double {
+        let step = max(pipeline.currentStep.rawValue, highWaterStep)
+        switch kind {
+        case .generation:
+            return Double(step) / Double(GenerationStep.allCases.count)
+        case .refinement:
+            let refineSteps: [GenerationStep] = [.generatingDSP, .generatingUI, .compiling, .installing]
+            let idx = refineSteps.firstIndex(of: pipeline.currentStep) ?? 0
+            return Double(idx) / Double(refineSteps.count)
+        }
+    }
+
+    init(kind: Kind) {
+        self.kind = kind
+    }
+
+    func startTimer() {
+        timerTask?.cancel()
+        timerTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                self?.elapsedSeconds += 1
+            }
+        }
+    }
+
+    func stopTimer() {
+        timerTask?.cancel()
+        timerTask = nil
+    }
+
+    func updateStep(from oldValue: GenerationStep, to newValue: GenerationStep) {
+        if newValue.rawValue > highWaterStep {
+            highWaterStep = newValue.rawValue
+            completedSteps.insert(oldValue.rawValue)
+        }
+    }
+}
+
 // MARK: - App state
 
 @Observable
@@ -77,6 +154,7 @@ final class AppState {
     var plugins: [Plugin] = []
     var showSetup: Bool = false
     var buildProgress: Double = 0
+    var activeBuild: ActiveBuild?
 
     func push(_ route: Route) {
         path.append(route)
@@ -84,6 +162,14 @@ final class AppState {
 
     func popToRoot() {
         path = NavigationPath()
+    }
+
+    /// Called when a build finishes (success or error). Cleans up active build and resets navigation.
+    func finishBuild() {
+        activeBuild?.stopTimer()
+        activeBuild = nil
+        buildProgress = 0
+        popToRoot()
     }
 
     func loadPlugins() {

--- a/Foundry/Services/GenerationPipeline.swift
+++ b/Foundry/Services/GenerationPipeline.swift
@@ -42,6 +42,7 @@ final class GenerationPipeline {
     private var task: Task<Void, Never>?
     private var lastRealEventDate = Date()  // only updated by real Claude events, not the watcher itself
     private var silenceTask: Task<Void, Never>?
+    private weak var appStateRef: AppState?
 
     private func log(_ message: String, style: PipelineLogLine.Style = .normal) {
         let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -94,6 +95,7 @@ final class GenerationPipeline {
     func run(config: GenerationConfig, appState: AppState) {
         guard !isRunning else { return }
 
+        appStateRef = appState
         isRunning = true
         currentStep = .preparingProject
         buildAttempt = 0
@@ -108,10 +110,18 @@ final class GenerationPipeline {
                 // Add plugin to library
                 PluginManager.add(plugin, to: &appState.plugins)
 
+                appState.finishBuild()
                 appState.push(.result(plugin: plugin))
+            } catch is CancellationError {
+                // User cancelled — silent cleanup, no error screen
+                self.stopSilenceWatcher()
+                self.isRunning = false
+                return
             } catch let error as GenerationError {
+                appState.finishBuild()
                 appState.push(.error(message: error.localizedDescription, config: config))
             } catch {
+                appState.finishBuild()
                 appState.push(.error(message: error.localizedDescription, config: config))
             }
 
@@ -123,6 +133,7 @@ final class GenerationPipeline {
     func refine(config: RefineConfig, appState: AppState) {
         guard !isRunning else { return }
 
+        appStateRef = appState
         isRunning = true
         currentStep = .generatingDSP
         buildAttempt = 0
@@ -136,13 +147,19 @@ final class GenerationPipeline {
 
                 PluginManager.update(plugin, in: &appState.plugins)
 
+                appState.finishBuild()
                 appState.push(.result(plugin: plugin))
+            } catch is CancellationError {
+                self.stopSilenceWatcher()
+                self.isRunning = false
+                return
             } catch let error as GenerationError {
-                // Build a GenerationConfig so the error view can retry
                 let genConfig = GenerationConfig(prompt: config.plugin.prompt)
+                appState.finishBuild()
                 appState.push(.error(message: error.localizedDescription, config: genConfig))
             } catch {
                 let genConfig = GenerationConfig(prompt: config.plugin.prompt)
+                appState.finishBuild()
                 appState.push(.error(message: error.localizedDescription, config: genConfig))
             }
 
@@ -406,6 +423,12 @@ final class GenerationPipeline {
                 log(msg, style: .success)
             }
             log("START: \(step.logLabel)...", style: .active)
+
+            // Keep global progress in sync even when the generation view isn't visible
+            if let appState = appStateRef, let build = appState.activeBuild {
+                build.updateStep(from: prev, to: step)
+                appState.buildProgress = build.progress
+            }
         }
     }
 

--- a/Foundry/Views/BuildQueueView.swift
+++ b/Foundry/Views/BuildQueueView.swift
@@ -1,0 +1,193 @@
+import SwiftUI
+
+struct BuildQueueView: View {
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let build = appState.activeBuild {
+                ScrollView {
+                    VStack(spacing: 0) {
+                        buildRow(build)
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            } else {
+                emptyState
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.windowBackgroundColor))
+        .navigationTitle("Builds")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Done") {
+                    appState.popToRoot()
+                }
+                .keyboardShortcut(.return, modifiers: .command)
+            }
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            Image(systemName: "hammer")
+                .font(.system(size: 36, weight: .thin))
+                .foregroundStyle(.quaternary)
+
+            VStack(spacing: 4) {
+                Text("NO ACTIVE BUILDS")
+                    .font(FoundryTheme.Fonts.azeretMono(12))
+                    .tracking(1.5)
+                    .foregroundStyle(.secondary)
+
+                Text("Generated plugins will appear here while building.")
+                    .font(.subheadline)
+                    .foregroundStyle(.tertiary)
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Build Row
+
+    private func buildRow(_ build: ActiveBuild) -> some View {
+        Button {
+            // Navigate to the generation/refine progress view
+            appState.popToRoot()
+            appState.push(build.route)
+        } label: {
+            VStack(spacing: 0) {
+                HStack(alignment: .top, spacing: 16) {
+                    // Status indicator
+                    VStack {
+                        if build.pipeline.isRunning {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                        }
+                    }
+                    .frame(width: 20)
+                    .padding(.top, 2)
+
+                    // Info
+                    VStack(alignment: .leading, spacing: 8) {
+                        // Name + time
+                        HStack(alignment: .firstTextBaseline) {
+                            Text(build.displayName)
+                                .font(FoundryTheme.Fonts.spaceGrotesk(16))
+                                .tracking(0.5)
+                                .foregroundStyle(.primary)
+                                .lineLimit(1)
+
+                            Spacer()
+
+                            Text(formattedTime(build.elapsedSeconds))
+                                .font(FoundryTheme.Fonts.azeretMono(11))
+                                .foregroundStyle(.tertiary)
+                                .monospacedDigit()
+                        }
+
+                        // Step + percentage
+                        HStack(spacing: 0) {
+                            Text(build.pipeline.currentStep.terminalLabel)
+                                .font(FoundryTheme.Fonts.azeretMono(10))
+                                .tracking(0.8)
+                                .foregroundStyle(.secondary)
+
+                            Spacer()
+
+                            Text("\(Int(appState.buildProgress * 100))%")
+                                .font(FoundryTheme.Fonts.azeretMono(10))
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+
+                        // Progress bar
+                        GeometryReader { geo in
+                            ZStack(alignment: .leading) {
+                                Rectangle()
+                                    .fill(FoundryTheme.Colors.borderSubtle)
+                                    .frame(height: 3)
+
+                                Rectangle()
+                                    .fill(Color.primary)
+                                    .frame(width: geo.size.width * appState.buildProgress, height: 3)
+                            }
+                        }
+                        .frame(height: 3)
+
+                        // Build attempt
+                        if build.pipeline.buildAttempt > 1 {
+                            Text("BUILD ATTEMPT \(build.pipeline.buildAttempt)")
+                                .font(FoundryTheme.Fonts.azeretMono(9))
+                                .tracking(0.8)
+                                .foregroundStyle(.orange)
+                        }
+                    }
+
+                    // Cancel button
+                    if build.pipeline.isRunning {
+                        Button {
+                            build.pipeline.cancel()
+                            build.stopTimer()
+                            appState.activeBuild = nil
+                            appState.buildProgress = 0
+                        } label: {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 24, height: 24)
+                                .background(FoundryTheme.Colors.borderSubtle, in: Circle())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 16)
+
+                // Bottom border
+                Rectangle()
+                    .fill(FoundryTheme.Colors.border)
+                    .frame(height: 1)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Helpers
+
+    private func formattedTime(_ seconds: Int) -> String {
+        let m = seconds / 60
+        let s = seconds % 60
+        return String(format: "%d:%02d", m, s)
+    }
+}
+
+#Preview("With Build") {
+    NavigationStack {
+        BuildQueueView()
+    }
+    .environment({
+        let s = AppState()
+        s.plugins = Plugin.samplePlugins
+        return s
+    }())
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Empty") {
+    NavigationStack {
+        BuildQueueView()
+    }
+    .environment(AppState())
+    .preferredColorScheme(.dark)
+}

--- a/Foundry/Views/GenerationProgressView.swift
+++ b/Foundry/Views/GenerationProgressView.swift
@@ -48,26 +48,21 @@ struct GenerationProgressView: View {
     @Environment(AppState.self) private var appState
     let config: GenerationConfig
 
-    @State private var pipeline = GenerationPipeline()
-    @State private var elapsedSeconds: Int = 0
-    @State private var completedSteps: Set<Int> = []
-    @State private var highWaterStep: Int = 0
-
-    @State private var showConsole = false
+    private var build: ActiveBuild? { appState.activeBuild }
 
     var body: some View {
         HStack(spacing: 0) {
             leftPanel
                 .frame(maxWidth: .infinity)
 
-            if showConsole {
+            if build?.showConsole == true, let build {
                 Divider()
 
                 TerminalView(
                     title: "Build Log",
-                    logLines: pipeline.logLines,
+                    logLines: build.pipeline.logLines,
                     elapsedTime: formattedTime,
-                    streamingText: pipeline.streamingText
+                    streamingText: build.pipeline.streamingText
                 )
                 .frame(maxWidth: .infinity)
             }
@@ -77,14 +72,25 @@ struct GenerationProgressView: View {
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
                 Button("Cancel") {
-                    pipeline.cancel()
+                    build?.pipeline.cancel()
+                    build?.stopTimer()
+                    appState.activeBuild = nil
+                    appState.buildProgress = 0
                     appState.popToRoot()
                 }
             }
             ToolbarItem(placement: .automatic) {
+                Button {
+                    appState.popToRoot()
+                } label: {
+                    Label("Back to Library", systemImage: "square.grid.2x2")
+                }
+                .help("Continue in background")
+            }
+            ToolbarItem(placement: .automatic) {
                 Toggle(isOn: Binding(
-                    get: { showConsole },
-                    set: { newValue in withAnimation { showConsole = newValue } }
+                    get: { build?.showConsole ?? false },
+                    set: { newValue in withAnimation { build?.showConsole = newValue } }
                 )) {
                     Label("Console", systemImage: "terminal")
                 }
@@ -92,24 +98,23 @@ struct GenerationProgressView: View {
             }
         }
         .onAppear {
-            pipeline.run(config: config, appState: appState)
-            appState.buildProgress = 0
+            // Only start a new build if there isn't one already running for this config
+            if appState.activeBuild == nil {
+                let newBuild = ActiveBuild(kind: .generation(config))
+                appState.activeBuild = newBuild
+                appState.buildProgress = 0
+                newBuild.pipeline.run(config: config, appState: appState)
+                newBuild.startTimer()
+            }
+            appState.activeBuild?.isViewingProgress = true
         }
         .onDisappear {
-            appState.buildProgress = 0
+            appState.activeBuild?.isViewingProgress = false
         }
-        .task {
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(1))
-                elapsedSeconds += 1
-            }
-        }
-        .onChange(of: pipeline.currentStep) { oldValue, newValue in
-            if newValue.rawValue > highWaterStep {
-                highWaterStep = newValue.rawValue
-                _ = completedSteps.insert(oldValue.rawValue)
-            }
-            appState.buildProgress = progress
+        .onChange(of: build?.pipeline.currentStep) { oldValue, newValue in
+            guard let oldValue, let newValue, let build else { return }
+            build.updateStep(from: oldValue, to: newValue)
+            appState.buildProgress = build.progress
         }
     }
 
@@ -120,15 +125,17 @@ struct GenerationProgressView: View {
             Spacer()
 
             VStack(spacing: 24) {
-                GenerationStepList(
-                    currentStep: pipeline.currentStep,
-                    completedSteps: completedSteps
-                )
-                .frame(maxWidth: 360)
-
-                ProgressView(value: progress)
-                    .tint(.accentColor)
+                if let build {
+                    GenerationStepList(
+                        currentStep: build.pipeline.currentStep,
+                        completedSteps: build.completedSteps
+                    )
                     .frame(maxWidth: 360)
+
+                    ProgressView(value: build.progress)
+                        .tint(.accentColor)
+                        .frame(maxWidth: 360)
+                }
             }
 
             Spacer()
@@ -138,13 +145,10 @@ struct GenerationProgressView: View {
 
     // MARK: - Helpers
 
-    private var progress: Double {
-        Double(max(pipeline.currentStep.rawValue, highWaterStep)) / Double(GenerationStep.allCases.count)
-    }
-
     private var formattedTime: String {
-        let m = elapsedSeconds / 60
-        let s = elapsedSeconds % 60
+        let seconds = build?.elapsedSeconds ?? 0
+        let m = seconds / 60
+        let s = seconds % 60
         return String(format: "%d:%02d", m, s)
     }
 }

--- a/Foundry/Views/PluginLibraryView.swift
+++ b/Foundry/Views/PluginLibraryView.swift
@@ -32,6 +32,21 @@ struct PluginLibraryView: View {
         }
         .navigationTitle("Foundry")
         .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    appState.push(.queue)
+                } label: {
+                    ZStack(alignment: .topTrailing) {
+                        Label("Builds", systemImage: "hammer")
+                        if appState.activeBuild?.pipeline.isRunning == true {
+                            Circle()
+                                .fill(.orange)
+                                .frame(width: 7, height: 7)
+                                .offset(x: 3, y: -3)
+                        }
+                    }
+                }
+            }
             ToolbarItem(placement: .primaryAction) {
                 Button {
                     appState.push(.prompt)

--- a/Foundry/Views/RefineProgressView.swift
+++ b/Foundry/Views/RefineProgressView.swift
@@ -4,56 +4,55 @@ struct RefineProgressView: View {
     @Environment(AppState.self) private var appState
     let config: RefineConfig
 
-    @State private var pipeline = GenerationPipeline()
-    @State private var elapsedSeconds: Int = 0
-    @State private var completedSteps: Set<Int> = []
-
+    private var build: ActiveBuild? { appState.activeBuild }
     private let refineSteps: [GenerationStep] = [.generatingDSP, .generatingUI, .compiling, .installing]
 
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
 
-            VStack(alignment: .leading, spacing: 24) {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(pipeline.currentStep.label)
-                        .font(.title2)
-                        .fontWeight(.medium)
-                        .contentTransition(.numericText())
+            if let build {
+                VStack(alignment: .leading, spacing: 24) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(build.pipeline.currentStep.label)
+                            .font(.title2)
+                            .fontWeight(.medium)
+                            .contentTransition(.numericText())
 
-                    Text(config.modification)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(2)
-                }
-
-                VStack(alignment: .leading, spacing: 8) {
-                    ProgressView(value: progress)
-                        .tint(.accentColor)
-
-                    HStack {
-                        if pipeline.buildAttempt > 1 {
-                            Text("Build attempt \(pipeline.buildAttempt)/3")
-                                .font(.caption)
-                                .foregroundStyle(.orange)
-                        }
-
-                        Spacer()
-
-                        Text("Step \(currentStepIndex + 1) of \(refineSteps.count)")
-                            .font(.caption)
-                            .foregroundStyle(.tertiary)
+                        Text(config.modification)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
                     }
-                }
 
-                StepListView(
-                    steps: refineSteps,
-                    currentStep: pipeline.currentStep,
-                    completedSteps: completedSteps,
-                    buildAttempt: pipeline.buildAttempt
-                )
+                    VStack(alignment: .leading, spacing: 8) {
+                        ProgressView(value: build.progress)
+                            .tint(.accentColor)
+
+                        HStack {
+                            if build.pipeline.buildAttempt > 1 {
+                                Text("Build attempt \(build.pipeline.buildAttempt)/3")
+                                    .font(.caption)
+                                    .foregroundStyle(.orange)
+                            }
+
+                            Spacer()
+
+                            Text("Step \(currentStepIndex + 1) of \(refineSteps.count)")
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
+
+                    StepListView(
+                        steps: refineSteps,
+                        currentStep: build.pipeline.currentStep,
+                        completedSteps: build.completedSteps,
+                        buildAttempt: build.pipeline.buildAttempt
+                    )
+                }
+                .frame(maxWidth: 440)
             }
-            .frame(maxWidth: 440)
 
             Spacer()
         }
@@ -67,39 +66,51 @@ struct RefineProgressView: View {
             }
             ToolbarItem(placement: .cancellationAction) {
                 Button("Cancel") {
-                    pipeline.cancel()
+                    build?.pipeline.cancel()
+                    build?.stopTimer()
+                    appState.activeBuild = nil
+                    appState.buildProgress = 0
                     appState.popToRoot()
                 }
             }
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    appState.popToRoot()
+                } label: {
+                    Label("Back to Library", systemImage: "square.grid.2x2")
+                }
+                .help("Continue in background")
+            }
         }
         .onAppear {
-            pipeline.refine(config: config, appState: appState)
-        }
-        .task {
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(1))
-                elapsedSeconds += 1
+            if appState.activeBuild == nil {
+                let newBuild = ActiveBuild(kind: .refinement(config))
+                appState.activeBuild = newBuild
+                newBuild.pipeline.refine(config: config, appState: appState)
+                newBuild.startTimer()
             }
+            appState.activeBuild?.isViewingProgress = true
         }
-        .onChange(of: pipeline.currentStep) { oldValue, newValue in
-            if newValue.rawValue > oldValue.rawValue {
-                _ = completedSteps.insert(oldValue.rawValue)
-            }
+        .onDisappear {
+            appState.activeBuild?.isViewingProgress = false
+        }
+        .onChange(of: build?.pipeline.currentStep) { oldValue, newValue in
+            guard let oldValue, let newValue, let build else { return }
+            build.updateStep(from: oldValue, to: newValue)
+            appState.buildProgress = build.progress
         }
     }
 
     private var currentStepIndex: Int {
-        refineSteps.firstIndex(of: pipeline.currentStep) ?? 0
-    }
-
-    private var progress: Double {
-        Double(currentStepIndex) / Double(refineSteps.count)
+        guard let build else { return 0 }
+        return refineSteps.firstIndex(of: build.pipeline.currentStep) ?? 0
     }
 
     private var formattedTime: String {
-        let minutes = elapsedSeconds / 60
-        let seconds = elapsedSeconds % 60
-        return String(format: "%d:%02d", minutes, seconds)
+        let seconds = build?.elapsedSeconds ?? 0
+        let minutes = seconds / 60
+        let secs = seconds % 60
+        return String(format: "%d:%02d", minutes, secs)
     }
 }
 


### PR DESCRIPTION
## Summary
- Allow navigating away from the generation/refine screen while the build continues in background
- Add a dedicated Build Queue page (toolbar hammer icon with orange badge) showing active build progress, step, elapsed time, and cancel
- Lift `GenerationPipeline` from view-local `@State` into shared `ActiveBuild` model on `AppState` so it survives navigation
- Handle `CancellationError` silently instead of showing an error screen

## Test plan
- [ ] Start a generation, click "Back to Library" toolbar button — build continues in background
- [ ] Click hammer icon in library toolbar — Build Queue page shows active build with progress
- [ ] Click on the build row in queue — navigates back to generation progress view
- [ ] Cancel from queue page — build stops, returns to library
- [ ] Let build complete while on library — result view appears automatically
- [ ] Open queue with no active build — shows empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)