### PR TITLE
feat: distinct refine flow + generation_type telemetry

### DIFF
--- a/Foundry/Models/AppState.swift
+++ b/Foundry/Models/AppState.swift
@@ -282,7 +282,7 @@ final class ActiveBuild {
         case .generation:
             return Double(step) / Double(GenerationStep.allCases.count)
         case .refinement:
-            let refineSteps: [GenerationStep] = [.generatingDSP, .generatingUI, .compiling, .installing]
+            let refineSteps: [GenerationStep] = [.generatingDSP, .compiling, .installing]
             let idx = refineSteps.firstIndex(of: pipeline.currentStep) ?? 0
             return Double(idx) / Double(refineSteps.count)
         }

--- a/Foundry/Models/GenerationTelemetry.swift
+++ b/Foundry/Models/GenerationTelemetry.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+// MARK: - Generation type
+
+enum GenerationType: String, Codable {
+    case generate
+    case refine
+    case preset
+}
+
 // MARK: - Telemetry record
 
 struct GenerationTelemetry: Codable, Identifiable {
@@ -8,6 +16,9 @@ struct GenerationTelemetry: Codable, Identifiable {
     let id: UUID
     let pluginId: UUID?
     let versionNumber: Int?
+
+    // Type
+    let generationType: GenerationType
 
     // Agent
     let agent: GenerationAgent
@@ -124,6 +135,8 @@ final class TelemetryBuilder {
     let id = UUID()
     var pluginId: UUID?
     var versionNumber: Int?
+
+    var generationType: GenerationType = .generate
 
     var agent: GenerationAgent = .claudeCode
     var model: String = ""
@@ -243,6 +256,7 @@ final class TelemetryBuilder {
             id: id,
             pluginId: pluginId,
             versionNumber: versionNumber,
+            generationType: generationType,
             agent: agent,
             model: model,
             originalPrompt: originalPrompt,

--- a/Foundry/Services/BuildLoop.swift
+++ b/Foundry/Services/BuildLoop.swift
@@ -39,14 +39,16 @@ enum BuildLoop {
         }
     }
 
-    /// Build loop with no artificial attempt limit.
-    /// Exits on success or task cancellation — the compiler is the only judge.
+    /// Build loop. For generation: unlimited retries (the compiler is the only judge).
+    /// For refine: capped at `maxAttempts` to avoid long loops for small edits.
     static func run(
         projectDir: URL,
         agent: GenerationAgent = .claudeCode,
         model: AgentModel = ModelCatalog.defaultModel,
         callbacks: PipelineCallbacks,
         telemetry: TelemetryBuilder? = nil,
+        skipConfigure: Bool = false,
+        maxAttempts: Int? = nil,
         dependencies: Dependencies? = nil
     ) async throws {
         let dependencies = dependencies ?? .live(agent: agent, model: model)
@@ -57,10 +59,16 @@ enum BuildLoop {
             try Task.checkCancellation()
 
             attempt += 1
+
+            // Enforce attempt cap when set (refine flow)
+            if let max = maxAttempts, attempt > max {
+                throw GenerationError.buildFailed("Build failed after \(max) attempts: \(lastErrors)")
+            }
+
             await callbacks.onBuildAttempt(attempt)
             await telemetry?.startBuildAttempt()
 
-            let buildResult = try await dependencies.build(projectDir, attempt > 1)
+            let buildResult = try await dependencies.build(projectDir, skipConfigure || attempt > 1)
 
             if buildResult.success {
                 let smokeOK = await dependencies.smokeTest(projectDir)

--- a/Foundry/Services/GenerationPipeline.swift
+++ b/Foundry/Services/GenerationPipeline.swift
@@ -161,6 +161,8 @@ final class GenerationPipeline {
                 appState.finishBuild()
                 appState.push(.result(plugin: plugin))
             } catch is CancellationError {
+                // Restore Source/ backup if refine was cancelled mid-flight
+                self.restoreRefineBackup(for: config.plugin)
                 if let tb = self.telemetry {
                     tb.outcome = .cancelled
                     self.saveTelemetry(tb)
@@ -196,6 +198,7 @@ final class GenerationPipeline {
         // Initialize telemetry
         let tb = TelemetryBuilder()
         telemetry = tb
+        tb.generationType = .generate
         tb.agent = config.agent
         tb.model = config.model.id
         tb.originalPrompt = config.prompt
@@ -424,6 +427,7 @@ final class GenerationPipeline {
         // Initialize telemetry
         let tb = TelemetryBuilder()
         telemetry = tb
+        tb.generationType = .refine
         let agent = config.plugin.agent ?? .claudeCode
         let model = config.plugin.model ?? agent.defaultModel
         tb.agent = agent
@@ -452,25 +456,31 @@ final class GenerationPipeline {
             throw GenerationError.assemblyFailed("Build directory no longer exists: \(buildDir)")
         }
 
-        // Copy archived build to a fresh temp directory for refining
-        let uuid = UUID().uuidString.prefix(8).lowercased()
-        let projectDir = URL(fileURLWithPath: "/tmp/foundry-build-\(uuid)")
-        do {
-            try FileManager.default.copyItem(at: archivedDir, to: projectDir)
-        } catch {
-            tb.outcome = .failedGeneration
-            tb.failureStage = .assembly
-            tb.failureMessage = error.localizedDescription
-            saveTelemetry(tb)
-            throw GenerationError.assemblyFailed("Failed to restore build for refining: \(error.localizedDescription)")
+        // Work directly in the archived directory for incremental builds.
+        // CMake cache paths remain valid → no reconfigure, only changed files recompile.
+        let projectDir = archivedDir
+
+        // Backup Source/ so we can rollback if the user cancels or the refine fails
+        let fm = FileManager.default
+        let sourceDir = projectDir.appendingPathComponent("Source")
+        let sourceBackup = projectDir.appendingPathComponent("Source.backup")
+        try? fm.removeItem(at: sourceBackup)
+        if fm.fileExists(atPath: sourceDir.path) {
+            try? fm.copyItem(at: sourceDir, to: sourceBackup)
         }
 
         // Lock CMakeLists.txt so Claude cannot modify it (prevents plugin rename)
         let cmakePath = projectDir.appendingPathComponent("CMakeLists.txt").path
-        try? FileManager.default.setAttributes(
-            [.immutable: true],
-            ofItemAtPath: cmakePath
-        )
+        try? fm.setAttributes([.immutable: true], ofItemAtPath: cmakePath)
+
+        // Helper to restore Source/ from backup on failure
+        func restoreSourceBackup() {
+            if fm.fileExists(atPath: sourceBackup.path) {
+                try? fm.removeItem(at: sourceDir)
+                try? fm.moveItem(at: sourceBackup, to: sourceDir)
+            }
+            try? fm.setAttributes([.immutable: false], ofItemAtPath: cmakePath)
+        }
 
         let callbacks = makeCallbacks()
 
@@ -531,6 +541,7 @@ final class GenerationPipeline {
         if let usage = genResult.tokenUsage { tb.tokenUsage.add(usage) }
 
         if isAIInfrastructureFailure(genResult.error) {
+            restoreSourceBackup()
             tb.outcome = .failedGeneration
             tb.failureStage = .generation
             tb.failureMessage = genResult.error
@@ -542,6 +553,7 @@ final class GenerationPipeline {
             let processorFile = projectDir.appendingPathComponent("Source/PluginProcessor.cpp")
             let processorContent = (try? String(contentsOf: processorFile, encoding: .utf8)) ?? ""
             if processorContent.isEmpty {
+                restoreSourceBackup()
                 tb.outcome = .failedGeneration
                 tb.failureStage = .generation
                 tb.failureMessage = genResult.error ?? "Claude did not modify the code"
@@ -553,20 +565,39 @@ final class GenerationPipeline {
         try Task.checkCancellation()
 
         // Unlock CMakeLists.txt before build (cmake needs to read it)
-        try? FileManager.default.setAttributes(
-            [.immutable: false],
-            ofItemAtPath: cmakePath
-        )
+        try? fm.setAttributes([.immutable: false], ofItemAtPath: cmakePath)
+
+        // Invalidate stale CMake cache if the build dir was relocated (e.g. archived to Application Support)
+        let buildCacheFile = projectDir.appendingPathComponent("build/CMakeCache.txt")
+        if let cacheContent = try? String(contentsOf: buildCacheFile, encoding: .utf8) {
+            let currentPath = projectDir.path
+            if !cacheContent.contains(currentPath) {
+                // Cache references a different directory — wipe it so CMake reconfigures cleanly
+                let buildSubdir = projectDir.appendingPathComponent("build")
+                try? fm.removeItem(at: buildSubdir)
+            }
+        }
+
+        let canSkipConfigure = fm.fileExists(atPath: buildCacheFile.path)
 
         setStep(.compiling)
         tb.buildStart = Date()
         do {
-            try await BuildLoop.run(projectDir: projectDir, agent: agent, model: model, callbacks: callbacks, telemetry: tb)
+            try await BuildLoop.run(
+                projectDir: projectDir,
+                agent: agent,
+                model: model,
+                callbacks: callbacks,
+                telemetry: tb,
+                skipConfigure: canSkipConfigure,
+                maxAttempts: 3
+            )
         } catch let error as GenerationError {
             tb.buildEnd = Date()
             tb.outcome = .failedBuild
             tb.failureStage = .build
             tb.failureMessage = error.localizedDescription
+            restoreSourceBackup()
             saveTelemetry(tb)
             throw error
         }
@@ -593,23 +624,23 @@ final class GenerationPipeline {
             tb.outcome = .failedInstall
             tb.failureStage = .install
             tb.failureMessage = error.localizedDescription
+            restoreSourceBackup()
             saveTelemetry(tb)
             throw GenerationError.installFailed(error.localizedDescription)
         }
         tb.installEnd = Date()
 
-        // Persist generation log to AppSupport before returning
-        let tempLog = projectDir.appendingPathComponent("generation.log")
+        // Persist generation log
+        let genLog = projectDir.appendingPathComponent("generation.log")
         let logsDir = FoundryPaths.generationLogsDirectory
-        try? FileManager.default.createDirectory(at: logsDir, withIntermediateDirectories: true)
-        if FileManager.default.fileExists(atPath: tempLog.path) {
+        try? fm.createDirectory(at: logsDir, withIntermediateDirectories: true)
+        if fm.fileExists(atPath: genLog.path) {
             let destLog = FoundryPaths.generationLogFile(for: config.plugin.id)
-            // Overwrite previous log (refine replaces the last generation)
-            try? FileManager.default.removeItem(at: destLog)
-            try? FileManager.default.copyItem(at: tempLog, to: destLog)
+            try? fm.removeItem(at: destLog)
+            try? fm.copyItem(at: genLog, to: destLog)
         }
 
-        // Create new version
+        // Create new version — archive the modified build to a new version directory
         let versionNumber = config.plugin.nextVersionNumber
 
         // Finalize telemetry
@@ -618,6 +649,7 @@ final class GenerationPipeline {
         tb.outcome = .success
         saveTelemetry(tb)
 
+        // Archive: copy the in-place modified build to v<N+1>
         let archivedBuildDir: String?
         do {
             archivedBuildDir = try PluginManager.archiveBuild(
@@ -629,6 +661,9 @@ final class GenerationPipeline {
             print("[Pipeline] Failed to archive refine build: \(error)")
             archivedBuildDir = nil
         }
+
+        // Clean up Source backup — refine succeeded
+        try? fm.removeItem(at: sourceBackup)
 
         let newVersion = PluginVersion(
             id: UUID(),
@@ -662,9 +697,6 @@ final class GenerationPipeline {
         }
         versions.append(newVersion)
         updated.versions = versions
-
-        // Clean up the temp working directory
-        BuildDirectoryCleaner.cleanAfterInstall(projectDir)
 
         return updated
     }
@@ -793,6 +825,22 @@ final class GenerationPipeline {
         case .vst3: [.vst3]
         case .both: [.au, .vst3]
         }
+    }
+
+    /// Restore Source/ from backup after a cancelled or failed refine.
+    /// This undoes in-place modifications to the archived build directory.
+    private func restoreRefineBackup(for plugin: Plugin) {
+        guard let buildDir = plugin.buildDirectory else { return }
+        let dir = URL(fileURLWithPath: buildDir)
+        let sourceDir = dir.appendingPathComponent("Source")
+        let sourceBackup = dir.appendingPathComponent("Source.backup")
+        let cmakePath = dir.appendingPathComponent("CMakeLists.txt").path
+        let fm = FileManager.default
+        if fm.fileExists(atPath: sourceBackup.path) {
+            try? fm.removeItem(at: sourceDir)
+            try? fm.moveItem(at: sourceBackup, to: sourceDir)
+        }
+        try? fm.setAttributes([.immutable: false], ofItemAtPath: cmakePath)
     }
 
     private func isAIInfrastructureFailure(_ message: String?) -> Bool {

--- a/Foundry/Services/TelemetryService.swift
+++ b/Foundry/Services/TelemetryService.swift
@@ -161,6 +161,7 @@ private struct TelemetryRow: Encodable {
     let user_id: UUID
     let plugin_id: UUID?
     let version_number: Int?
+    let generation_type: String
     let agent: String
     let model: String
     let original_prompt: String
@@ -200,6 +201,7 @@ private struct TelemetryRow: Encodable {
         user_id = userId
         plugin_id = t.pluginId
         version_number = t.versionNumber
+        generation_type = t.generationType.rawValue
         agent = t.agent.rawValue
         model = t.model
         original_prompt = t.originalPrompt

--- a/Foundry/Views/BuildQueueView.swift
+++ b/Foundry/Views/BuildQueueView.swift
@@ -24,6 +24,8 @@ struct BuildQueueView: View {
                 Button("Done") {
                     appState.popToRoot()
                 }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
                 .keyboardShortcut(.return, modifiers: .command)
             }
         }

--- a/Foundry/Views/GenerationProgressView.swift
+++ b/Foundry/Views/GenerationProgressView.swift
@@ -19,6 +19,17 @@ enum GenerationStep: Int, CaseIterable {
         }
     }
 
+    /// Labels used in refine mode — editing, not generating.
+    var refineLabel: String {
+        switch self {
+        case .preparingProject: "Preparing project"
+        case .generatingDSP: "Editing code"
+        case .generatingUI: "Editing code"
+        case .compiling: "Compiling"
+        case .installing: "Installing"
+        }
+    }
+
     var terminalLabel: String {
         switch self {
         case .preparingProject: "PREPARING PROJECT"
@@ -64,7 +75,7 @@ struct GenerationProgressView: View {
 
     private var visibleSteps: [GenerationStep] {
         isRefine
-            ? [.generatingDSP, .generatingUI, .compiling, .installing]
+            ? [.generatingDSP, .compiling, .installing]
             : GenerationStep.allCases
     }
 
@@ -166,7 +177,8 @@ struct GenerationProgressView: View {
                         GenerationStepList(
                             steps: visibleSteps,
                             currentStep: build.pipeline.currentStep,
-                            completedSteps: build.completedSteps
+                            completedSteps: build.completedSteps,
+                            isRefine: isRefine
                         )
                         .frame(maxWidth: 360)
 
@@ -319,14 +331,16 @@ struct GenerationStepList: View {
     var steps: [GenerationStep] = GenerationStep.allCases
     let currentStep: GenerationStep
     let completedSteps: Set<Int>
+    var isRefine: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
             ForEach(steps, id: \.self) { step in
                 GenerationStepRow(
                     step: step,
-                    isActive: currentStep == step,
-                    isDone: completedSteps.contains(step.rawValue)
+                    isActive: currentStep == step || (isRefine && step == .generatingDSP && currentStep == .generatingUI),
+                    isDone: completedSteps.contains(step.rawValue),
+                    isRefine: isRefine
                 )
             }
         }
@@ -339,6 +353,7 @@ struct GenerationStepRow: View {
     let step: GenerationStep
     let isActive: Bool
     let isDone: Bool
+    var isRefine: Bool = false
 
     private var isPending: Bool { !isDone && !isActive }
 
@@ -360,7 +375,7 @@ struct GenerationStepRow: View {
                     .frame(width: 20)
             }
 
-            Text(step.label)
+            Text(isRefine ? step.refineLabel : step.label)
                 .font(.system(.body, design: .monospaced))
                 .foregroundStyle(isPending ? .tertiary : .primary)
 

--- a/Foundry/Views/PluginDetailView.swift
+++ b/Foundry/Views/PluginDetailView.swift
@@ -252,24 +252,10 @@ struct PluginDetailView: View {
 
             Spacer()
 
-            Button {
-                dismiss()
-            } label: {
-                Text("DONE")
-                    .font(FoundryTheme.Fonts.azeretMono(9))
-                    .tracking(1.2)
-                    .foregroundStyle(.primary)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 6)
-                    .background(FoundryTheme.Colors.backgroundDeep)
-                    .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 4, style: .continuous)
-                            .strokeBorder(FoundryTheme.Colors.border, lineWidth: 1)
-                    )
-            }
-            .buttonStyle(.plain)
-            .keyboardShortcut(.cancelAction)
+            Button("Done") { dismiss() }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .keyboardShortcut(.cancelAction)
         }
         .padding(.horizontal, FoundryTheme.Spacing.lg)
         .padding(.vertical, FoundryTheme.Spacing.md)

--- a/Foundry/Views/ResultView.swift
+++ b/Foundry/Views/ResultView.swift
@@ -37,6 +37,8 @@ struct ResultView: View {
                 Button("Done") {
                     appState.popToRoot()
                 }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
                 .keyboardShortcut(.return, modifiers: .command)
             }
         }

--- a/Foundry/Views/VersionHistoryView.swift
+++ b/Foundry/Views/VersionHistoryView.swift
@@ -28,7 +28,7 @@ struct VersionHistoryView: View {
             Divider()
             versionList
         }
-        .frame(width: 440, height: 400)
+        .frame(width: 480, height: 420)
         .background(FoundryTheme.Colors.background)
         .alert("Restore failed", isPresented: Binding(
             get: { restoreError != nil },
@@ -65,13 +65,14 @@ struct VersionHistoryView: View {
                     .font(FoundryTheme.Fonts.azeretMono(11))
                     .tracking(1.5)
                     .foregroundStyle(.primary)
-                Text(plugin.name)
+                Text("\(plugin.name) · \(plugin.versions.count) versions")
                     .font(FoundryTheme.Fonts.azeretMono(10))
                     .foregroundStyle(FoundryTheme.Colors.textMuted)
             }
             Spacer()
             Button("Done") { dismiss() }
                 .buttonStyle(.borderedProminent)
+                .controlSize(.large)
                 .keyboardShortcut(.cancelAction)
         }
         .padding(16)
@@ -81,41 +82,43 @@ struct VersionHistoryView: View {
 
     private var versionList: some View {
         ScrollView {
-            LazyVStack(spacing: 0) {
+            LazyVStack(spacing: 1) {
                 ForEach(plugin.versions.sorted(by: { $0.versionNumber > $1.versionNumber })) { version in
-                    VStack(spacing: 0) {
-                        versionRow(version)
-                        Rectangle().fill(FoundryTheme.Colors.border).frame(height: 1)
-                    }
+                    versionRow(version)
                 }
             }
+            .padding(.vertical, 4)
         }
     }
 
     private func versionRow(_ version: PluginVersion) -> some View {
         HStack(spacing: 12) {
-            // Version badge
-            VStack(spacing: 2) {
+            // Version badge with type indicator
+            VStack(spacing: 4) {
                 Text("v\(version.versionNumber)")
-                    .font(FoundryTheme.Fonts.spaceGrotesk(16))
+                    .font(FoundryTheme.Fonts.spaceGrotesk(16, weight: version.isActive ? .semibold : .regular))
                     .foregroundStyle(version.isActive ? .primary : FoundryTheme.Colors.textSecondary)
-                if version.isActive {
-                    Text("ACTIVE")
-                        .font(FoundryTheme.Fonts.azeretMono(7))
-                        .tracking(1)
-                        .foregroundStyle(FoundryTheme.Colors.textMuted)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(FoundryTheme.Colors.border)
-                }
+
+                // Type tag
+                let isInitial = version.versionNumber == 1
+                Text(isInitial ? "CREATED" : "REFINED")
+                    .font(FoundryTheme.Fonts.azeretMono(7))
+                    .tracking(0.8)
+                    .foregroundStyle(isInitial ? .green.opacity(0.8) : .blue.opacity(0.8))
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1.5)
+                    .background(
+                        (isInitial ? Color.green : Color.blue).opacity(0.1),
+                        in: RoundedRectangle(cornerRadius: 3)
+                    )
             }
-            .frame(width: 56)
+            .frame(width: 60)
 
             // Details
-            VStack(alignment: .leading, spacing: 3) {
+            VStack(alignment: .leading, spacing: 4) {
                 Text(version.prompt)
-                    .font(FoundryTheme.Fonts.azeretMono(10))
-                    .foregroundStyle(FoundryTheme.Colors.textSecondary)
+                    .font(FoundryTheme.Fonts.azeretMono(10.5))
+                    .foregroundStyle(version.isActive ? .primary : FoundryTheme.Colors.textSecondary)
                     .lineLimit(2)
 
                 HStack(spacing: 8) {
@@ -123,27 +126,46 @@ struct VersionHistoryView: View {
                         .font(FoundryTheme.Fonts.azeretMono(9))
                         .foregroundStyle(FoundryTheme.Colors.textFaint)
 
-                    if version.hasBuildCache {
-                        Image(systemName: "internaldrive")
-                            .font(.system(size: 8))
+                    if let agent = version.agent {
+                        Text(agent.rawValue)
+                            .font(FoundryTheme.Fonts.azeretMono(8))
                             .foregroundStyle(FoundryTheme.Colors.textFaint)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(FoundryTheme.Colors.border, in: RoundedRectangle(cornerRadius: 2))
+                    }
+
+                    if version.hasBuildCache {
+                        HStack(spacing: 2) {
+                            Image(systemName: "internaldrive")
+                                .font(.system(size: 7))
+                            Text("cached")
+                                .font(FoundryTheme.Fonts.azeretMono(8))
+                        }
+                        .foregroundStyle(FoundryTheme.Colors.textFaint)
                     }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            // Actions
+            // Status / Actions
             if version.isActive {
-                Image(systemName: "checkmark.circle.fill")
-                    .foregroundStyle(FoundryTheme.Colors.textMuted)
-                    .font(.system(size: 14))
+                HStack(spacing: 4) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 12))
+                    Text("ACTIVE")
+                        .font(FoundryTheme.Fonts.azeretMono(8))
+                        .tracking(0.5)
+                }
+                .foregroundStyle(.green.opacity(0.8))
             } else {
                 Menu {
-                    Button("Restore", systemImage: "arrow.counterclockwise") {
+                    Button("Restore this version", systemImage: "arrow.counterclockwise") {
                         restoreVersion(version)
                     }
                     .disabled(!version.hasBuildCache)
                     if version.hasBuildCache {
+                        Divider()
                         Button("Clear build cache", systemImage: "trash", role: .destructive) {
                             versionToDelete = version
                         }
@@ -159,7 +181,13 @@ struct VersionHistoryView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
-        .background(version.isActive ? FoundryTheme.Colors.backgroundCard : .clear)
+        .background(
+            version.isActive
+                ? FoundryTheme.Colors.backgroundCard
+                : .clear
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .padding(.horizontal, 4)
     }
 
     // MARK: - Actions

--- a/supabase/migrations/20260322160000_add_generation_type.sql
+++ b/supabase/migrations/20260322160000_add_generation_type.sql
@@ -1,0 +1,6 @@
+-- Add generation_type column to differentiate generate, refine, and preset flows
+alter table public.generation_telemetry
+  add column generation_type text not null default 'generate';
+
+-- Index for filtering by type
+create index idx_telemetry_generation_type on public.generation_telemetry(generation_type);


### PR DESCRIPTION
## Summary
- **Distinct refine flow**: 3 steps (Editing code → Compiling → Installing) instead of reusing the 5-step generation pipeline. Build loop capped at 3 attempts to prevent endless loops for small edits.
- **Source backup/restore**: Refine works in-place on the archived build directory with automatic rollback on failure or cancellation.
- **generation_type telemetry**: Tracks `generate`, `refine`, or `preset` in both local storage and Supabase (`generation_type` column added via migration).
- **UI consistency**: All "Done" buttons standardized to `.borderedProminent` style across PluginDetail, VersionHistory, Result, and BuildQueue views.

## Test plan
- [ ] Generate a new plugin — verify 5 steps (Preparing → DSP → UI → Compiling → Installing)
- [ ] Refine an existing plugin — verify 3 steps (Editing code → Compiling → Installing) with max 3 build attempts
- [ ] Cancel a refine mid-flight — verify Source/ is restored from backup
- [ ] Check Supabase `generation_telemetry` table has `generation_type` column populated
- [ ] Verify all "Done" buttons are blue filled across the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)