### PR TITLE
feat: add Codex CLI as generation backend

### DIFF
--- a/src-tauri/src/platform/linux.rs
+++ b/src-tauri/src/platform/linux.rs
@@ -33,6 +33,19 @@ pub fn resolve_claude_path() -> Option<String> {
     }
 }
 
+/// Resolve the Codex CLI binary path via login shell.
+pub fn resolve_codex_path() -> Option<String> {
+    let output = Command::new("/bin/bash")
+        .args(["-l", "-c", "which codex"])
+        .output()
+        .ok()?;
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
+
 /// Resolve a command path using the login shell.
 pub fn resolve_command(cmd: &str) -> String {
     Command::new("/bin/bash")

--- a/src-tauri/src/platform/macos.rs
+++ b/src-tauri/src/platform/macos.rs
@@ -6,6 +6,7 @@ use std::sync::RwLock;
 
 static SHELL_ENV: RwLock<Option<Vec<(String, String)>>> = RwLock::new(None);
 static CLAUDE_PATH: RwLock<Option<Option<String>>> = RwLock::new(None);
+static CODEX_PATH: RwLock<Option<Option<String>>> = RwLock::new(None);
 
 fn resolve_shell_environment() -> Vec<(String, String)> {
     let output = Command::new("/bin/zsh")
@@ -54,10 +55,29 @@ pub fn resolve_claude_path() -> Option<String> {
     result
 }
 
+/// Resolve the Codex CLI binary path via the cached shell environment.
+pub fn resolve_codex_path() -> Option<String> {
+    {
+        let guard = CODEX_PATH.read().unwrap();
+        if let Some(cached) = guard.as_ref() {
+            return cached.clone();
+        }
+    }
+    let resolved = resolve_command("codex");
+    let result = if resolved == "codex" {
+        None
+    } else {
+        Some(resolved)
+    };
+    *CODEX_PATH.write().unwrap() = Some(result.clone());
+    result
+}
+
 /// Clear cached shell environment and tool paths so newly installed tools are detected.
 pub fn invalidate_shell_cache() {
     *SHELL_ENV.write().unwrap() = None;
     *CLAUDE_PATH.write().unwrap() = None;
+    *CODEX_PATH.write().unwrap() = None;
 }
 
 fn path_from_cached_env(cmd: &str) -> Option<String> {

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -33,6 +33,10 @@ pub fn resolve_claude_path() -> Option<String> {
     imp::resolve_claude_path()
 }
 
+pub fn resolve_codex_path() -> Option<String> {
+    imp::resolve_codex_path()
+}
+
 pub fn resolve_command(cmd: &str) -> String {
     imp::resolve_command(cmd)
 }

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -23,6 +23,20 @@ pub fn resolve_claude_path() -> Option<String> {
     }
 }
 
+/// Resolve Codex CLI path using `where` on Windows.
+pub fn resolve_codex_path() -> Option<String> {
+    let output = Command::new("cmd")
+        .args(["/C", "where", "codex"])
+        .output()
+        .ok()?;
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        stdout.lines().next().map(|s| s.trim().to_string())
+    } else {
+        None
+    }
+}
+
 /// Resolve a command path using `where`.
 pub fn resolve_command(cmd: &str) -> String {
     Command::new("cmd")

--- a/src-tauri/src/services/agent_service.rs
+++ b/src-tauri/src/services/agent_service.rs
@@ -1,0 +1,110 @@
+//! Unified agent dispatcher.
+//!
+//! Routes `run` and `fix` calls to either `claude_code_service` or `codex_service`
+//! based on the agent identifier, allowing the generation pipeline to be backend-agnostic.
+
+use crate::services::{claude_code_service, codex_service};
+pub use claude_code_service::{ClaudeEvent, RunResult};
+
+/// Resolve the CLI path for the given agent.
+pub fn resolve_agent_path(agent: &str) -> Option<String> {
+    match normalized_agent(agent) {
+        "codex" => codex_service::resolve_codex_path(),
+        _ => claude_code_service::resolve_claude_path(),
+    }
+}
+
+/// Human-readable agent name for log messages.
+pub fn agent_display_name(agent: &str) -> &'static str {
+    match normalized_agent(agent) {
+        "codex" => "Codex",
+        _ => "Claude Code",
+    }
+}
+
+/// Run the agent CLI with the given prompt, dispatching to the correct backend.
+pub async fn run(
+    agent: &str,
+    cli_path: &str,
+    prompt: &str,
+    project_dir: &str,
+    model_flag: &str,
+    mode: &str,
+    on_event: impl Fn(ClaudeEvent) + Send + 'static,
+    cancel_rx: tokio::sync::watch::Receiver<bool>,
+) -> RunResult {
+    match normalized_agent(agent) {
+        "codex" => {
+            codex_service::run(
+                cli_path,
+                prompt,
+                project_dir,
+                model_flag,
+                mode,
+                on_event,
+                cancel_rx,
+            )
+            .await
+        }
+        _ => {
+            claude_code_service::run(
+                cli_path,
+                prompt,
+                project_dir,
+                model_flag,
+                mode,
+                on_event,
+                cancel_rx,
+            )
+            .await
+        }
+    }
+}
+
+/// Run a fix pass for build errors, dispatching to the correct backend.
+pub async fn fix(
+    agent: &str,
+    cli_path: &str,
+    errors: &str,
+    project_dir: &str,
+    attempt: i32,
+    model_flag: &str,
+    on_event: impl Fn(ClaudeEvent) + Send + 'static,
+    cancel_rx: tokio::sync::watch::Receiver<bool>,
+) -> RunResult {
+    match normalized_agent(agent) {
+        "codex" => {
+            codex_service::fix(
+                cli_path,
+                errors,
+                project_dir,
+                attempt,
+                model_flag,
+                on_event,
+                cancel_rx,
+            )
+            .await
+        }
+        _ => {
+            claude_code_service::fix(
+                cli_path,
+                errors,
+                project_dir,
+                attempt,
+                model_flag,
+                on_event,
+                cancel_rx,
+            )
+            .await
+        }
+    }
+}
+
+/// Normalize agent identifier to a canonical form.
+fn normalized_agent(agent: &str) -> &'static str {
+    if agent.to_ascii_lowercase().contains("codex") {
+        "codex"
+    } else {
+        "claude"
+    }
+}

--- a/src-tauri/src/services/auth_service.rs
+++ b/src-tauri/src/services/auth_service.rs
@@ -1,7 +1,7 @@
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use std::sync::{Mutex, LazyLock};
+use std::sync::{LazyLock, Mutex};
 
 static SUPABASE_URL_DEFAULT: &str = "https://bpqqfpdaigphewgobmpe.supabase.co";
 static SUPABASE_ANON_KEY_DEFAULT: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJwcXFmcGRhaWdwaGV3Z29ibXBlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzQwODc3NTYsImV4cCI6MjA4OTY2Mzc1Nn0.YKFmmJk39st-P68Dvztn9YHSCteXWGAvMNyM3hNofy4";

--- a/src-tauri/src/services/codex_service.rs
+++ b/src-tauri/src/services/codex_service.rs
@@ -1,0 +1,692 @@
+use std::path::Path;
+use std::process::Stdio;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+
+use crate::services::claude_code_service::{ClaudeEvent, RunResult};
+
+/// Resolved path of the `codex` CLI binary.
+pub fn resolve_codex_path() -> Option<String> {
+    crate::platform::resolve_codex_path()
+}
+
+/// Run Codex CLI with JSONL output, parsing events in real time.
+///
+/// The interface mirrors `claude_code_service::run` so the pipeline can
+/// dispatch to either backend transparently.
+pub async fn run(
+    codex_path: &str,
+    prompt: &str,
+    project_dir: &str,
+    model_flag: &str,
+    mode: &str,
+    on_event: impl Fn(ClaudeEvent) + Send + 'static,
+    mut cancel_rx: tokio::sync::watch::Receiver<bool>,
+) -> RunResult {
+    const IDLE_HEARTBEAT_SECS: u64 = 15;
+
+    // Codex has no --append-system-prompt, so we bake the system instructions
+    // into the prompt itself.
+    let system_instructions = mode_system_instructions(mode);
+    let full_prompt = if system_instructions.is_empty() {
+        prompt.to_string()
+    } else {
+        format!("{}\n\n---\n\n{}", system_instructions, prompt)
+    };
+
+    let max_turns = mode_max_turns(mode);
+
+    // Build the codex exec command
+    let mut args = vec![
+        "exec".to_string(),
+        full_prompt.clone(),
+        "--json".to_string(),
+        "--dangerously-bypass-approvals-and-sandbox".to_string(),
+        "-C".to_string(),
+        project_dir.to_string(),
+        "-m".to_string(),
+        model_flag.to_string(),
+    ];
+
+    // Codex doesn't have --max-turns, but we track turns ourselves
+    // and kill the process if it exceeds the limit.
+    let turn_limit: i64 = max_turns.parse().unwrap_or(50);
+
+    // For generate modes, add --ephemeral to avoid session persistence
+    if mode.starts_with("generate") || mode == "plan" {
+        args.push("--ephemeral".to_string());
+    }
+
+    let env = crate::services::claude_code_service::shell_environment();
+
+    // Codex hangs when stdin is /dev/null — it needs a pipe that closes immediately.
+    let mut child = match Command::new(codex_path)
+        .args(&args)
+        .envs(env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            let msg = format!("Failed to launch Codex CLI: {}", e);
+            on_event(ClaudeEvent::Error(msg.clone()));
+            return RunResult {
+                success: false,
+                output: String::new(),
+                error: Some(msg),
+                input_tokens: None,
+                output_tokens: None,
+                cache_read_tokens: None,
+                cost_usd: None,
+                num_turns: None,
+            };
+        }
+    };
+
+    // Close stdin immediately so Codex gets EOF (it hangs on /dev/null)
+    drop(child.stdin.take());
+
+    on_event(ClaudeEvent::Text(format!(
+        "MODEL SESSION · provider=codex · mode={} · model={} · max-turns={}",
+        mode, model_flag, turn_limit
+    )));
+
+    let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
+    let mut stdout_reader = BufReader::new(stdout).lines();
+    let mut stderr_reader = BufReader::new(stderr).lines();
+
+    let mut all_output = String::new();
+    let mut stderr_output = String::new();
+    let mut stdout_done = false;
+    let mut stderr_done = false;
+    let mut last_activity = std::time::Instant::now();
+    let mut last_heartbeat_second = 0;
+    let mut saw_expected_outputs = expected_output_files_exist(project_dir, mode);
+    let mut current_turns: i64 = 0;
+
+    // Captured from turn.completed events
+    let mut total_input_tokens: i64 = 0;
+    let mut total_output_tokens: i64 = 0;
+    let mut total_cached_tokens: i64 = 0;
+    let mut final_success = true; // Codex doesn't have explicit success/failure in events
+
+    let watchdog_secs = match mode {
+        "generate" => 360,
+        "generate_processor" | "generate_ui" | "refine" | "quality_audit" => 300,
+        _ => 900,
+    };
+    let no_write_timeout_secs = match mode {
+        "generate_processor" => Some(75),
+        "generate_ui" => Some(45),
+        _ => None,
+    };
+    let watchdog = tokio::time::sleep(std::time::Duration::from_secs(watchdog_secs));
+    tokio::pin!(watchdog);
+    let mut heartbeat = tokio::time::interval(std::time::Duration::from_secs(IDLE_HEARTBEAT_SECS));
+
+    loop {
+        if stdout_done && stderr_done {
+            break;
+        }
+
+        tokio::select! {
+            biased;
+
+            _ = cancel_rx.changed() => {
+                if *cancel_rx.borrow() {
+                    let _ = child.kill().await;
+                    return RunResult {
+                        success: false, output: all_output, error: Some("Cancelled".into()),
+                        input_tokens: None, output_tokens: None, cache_read_tokens: None, cost_usd: None, num_turns: None,
+                    };
+                }
+            }
+
+            _ = &mut watchdog => {
+                on_event(ClaudeEvent::Error(format!(
+                    "Process killed by {}s watchdog",
+                    watchdog_secs
+                )));
+                let _ = child.kill().await;
+                return RunResult {
+                    success: false, output: all_output, error: Some("Watchdog timeout".into()),
+                    input_tokens: None, output_tokens: None, cache_read_tokens: None, cost_usd: None, num_turns: None,
+                };
+            }
+
+            _ = heartbeat.tick() => {
+                let idle_for = last_activity.elapsed().as_secs();
+                if let Some(timeout_secs) = no_write_timeout_secs {
+                    if !saw_expected_outputs && idle_for >= timeout_secs {
+                        let message = format!(
+                            "Expected output files were not created after {}s in {} mode",
+                            timeout_secs, mode
+                        );
+                        on_event(ClaudeEvent::Error(message.clone()));
+                        let _ = child.kill().await;
+                        return RunResult {
+                            success: false, output: all_output, error: Some(message),
+                            input_tokens: if total_input_tokens > 0 { Some(total_input_tokens) } else { None },
+                            output_tokens: if total_output_tokens > 0 { Some(total_output_tokens) } else { None },
+                            cache_read_tokens: if total_cached_tokens > 0 { Some(total_cached_tokens) } else { None },
+                            cost_usd: None,
+                            num_turns: Some(current_turns),
+                        };
+                    }
+                }
+                if idle_for >= IDLE_HEARTBEAT_SECS && idle_for != last_heartbeat_second {
+                    if !saw_expected_outputs {
+                        saw_expected_outputs = expected_output_files_exist(project_dir, mode);
+                    }
+                    last_heartbeat_second = idle_for;
+                    on_event(ClaudeEvent::Text(format!(
+                        "Heartbeat: no new Codex output for {}s. The model is likely drafting files or waiting for a tool result.",
+                        idle_for
+                    )));
+                }
+            }
+
+            line = stdout_reader.next_line(), if !stdout_done => {
+                match line {
+                    Ok(Some(text)) => {
+                        last_activity = std::time::Instant::now();
+                        last_heartbeat_second = 0;
+                        all_output.push_str(&text);
+                        all_output.push('\n');
+
+                        for event in parse_codex_events(&text, &mut current_turns, &mut total_input_tokens, &mut total_output_tokens, &mut total_cached_tokens, &mut final_success) {
+                            on_event(event);
+                        }
+
+                        if !saw_expected_outputs {
+                            saw_expected_outputs = expected_output_files_exist(project_dir, mode);
+                        }
+
+                        // Kill if we've exceeded turn limit
+                        if current_turns >= turn_limit {
+                            on_event(ClaudeEvent::Text(format!(
+                                "Turn limit reached ({}/{}), stopping Codex.",
+                                current_turns, turn_limit
+                            )));
+                            let _ = child.kill().await;
+                            stdout_done = true;
+                            stderr_done = true;
+                        }
+                    }
+                    Ok(None) => stdout_done = true,
+                    Err(e) => {
+                        last_activity = std::time::Instant::now();
+                        stderr_output.push_str(&format!("Failed to read Codex stdout: {}\n", e));
+                        stdout_done = true;
+                    }
+                }
+            }
+
+            line = stderr_reader.next_line(), if !stderr_done => {
+                match line {
+                    Ok(Some(text)) => {
+                        last_activity = std::time::Instant::now();
+                        last_heartbeat_second = 0;
+                        stderr_output.push_str(&text);
+                        stderr_output.push('\n');
+                        let trimmed = text.trim();
+                        if !trimmed.is_empty() {
+                            on_event(ClaudeEvent::Stderr(trimmed.to_string()));
+                        }
+                    }
+                    Ok(None) => stderr_done = true,
+                    Err(e) => {
+                        last_activity = std::time::Instant::now();
+                        stderr_output.push_str(&format!("Failed to read Codex stderr: {}\n", e));
+                        stderr_done = true;
+                    }
+                }
+            }
+        }
+    }
+
+    let status = child.wait().await;
+    let exit_ok = status.map(|s| s.success()).unwrap_or(false);
+
+    let error = if exit_ok {
+        None
+    } else if !stderr_output.trim().is_empty() {
+        Some(stderr_output.trim().to_string())
+    } else if !all_output.trim().is_empty() {
+        Some("Codex CLI exited with error; see stdout for details".into())
+    } else {
+        Some("Codex CLI exited with error".into())
+    };
+
+    RunResult {
+        success: exit_ok && final_success,
+        output: all_output,
+        error,
+        input_tokens: if total_input_tokens > 0 {
+            Some(total_input_tokens)
+        } else {
+            None
+        },
+        output_tokens: if total_output_tokens > 0 {
+            Some(total_output_tokens)
+        } else {
+            None
+        },
+        cache_read_tokens: if total_cached_tokens > 0 {
+            Some(total_cached_tokens)
+        } else {
+            None
+        },
+        cost_usd: None, // Codex JSONL doesn't report cost
+        num_turns: Some(current_turns),
+    }
+}
+
+/// Run Codex for a fix pass (build errors).
+pub async fn fix(
+    codex_path: &str,
+    errors: &str,
+    project_dir: &str,
+    attempt: i32,
+    model_flag: &str,
+    on_event: impl Fn(ClaudeEvent) + Send + 'static,
+    cancel_rx: tokio::sync::watch::Receiver<bool>,
+) -> RunResult {
+    let prompt = format!(
+        "Build failed (attempt {}). Fix ALL errors in 2 turns.\n\
+        Turn 1: Read ALL Source/ files.\n\
+        Turn 2: Fix ALL issues.\n\n\
+        Errors:\n{}\n\n\
+        Rules: ONLY edit Source/ files. Do NOT touch CMakeLists.txt. C++17, juce:: prefix everywhere,\n\
+        juce::Font(juce::FontOptions(float)) not juce::Font(float), .h/.cpp signatures must match.\n\
+        Linker errors = your source code, NOT CMakeLists.txt.",
+        attempt, errors
+    );
+    run(
+        codex_path,
+        &prompt,
+        project_dir,
+        model_flag,
+        "refine",
+        on_event,
+        cancel_rx,
+    )
+    .await
+}
+
+// ---- Codex JSONL event parsing ----
+
+/// Parse a single JSONL line from Codex and convert to ClaudeEvent(s).
+///
+/// Codex emits these event types:
+/// - `thread.started` — session begins
+/// - `turn.started` — new agent turn
+/// - `item.started` — item in progress (command, file change)
+/// - `item.completed` — item finished (agent_message, command_execution, file_change, reasoning, error)
+/// - `turn.completed` — turn finished with usage stats
+/// - `turn.failed` — turn failed
+/// - `error` — general error
+fn parse_codex_events(
+    line: &str,
+    current_turns: &mut i64,
+    total_input_tokens: &mut i64,
+    total_output_tokens: &mut i64,
+    total_cached_tokens: &mut i64,
+    final_success: &mut bool,
+) -> Vec<ClaudeEvent> {
+    if line.is_empty() {
+        return vec![];
+    }
+    let json: serde_json::Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(_) => return vec![],
+    };
+
+    let event_type = json["type"].as_str().unwrap_or("");
+    let mut events = Vec::new();
+
+    match event_type {
+        "thread.started" => {
+            let thread_id = json["thread_id"].as_str().unwrap_or("?");
+            events.push(ClaudeEvent::Text(format!(
+                "Codex session started · thread={}",
+                &thread_id[..thread_id.len().min(12)]
+            )));
+        }
+
+        "turn.started" => {
+            *current_turns += 1;
+            events.push(ClaudeEvent::Text(format!("Turn {} started", current_turns)));
+        }
+
+        // item.started — show in-progress commands and file changes
+        "item.started" => {
+            let item = &json["item"];
+            let item_type = item["type"].as_str().unwrap_or("");
+
+            match item_type {
+                "command_execution" => {
+                    if let Some(cmd) = item["command"].as_str() {
+                        // Strip the shell wrapper to show the actual command
+                        let display_cmd = cmd
+                            .strip_prefix("/bin/zsh -lc ")
+                            .or_else(|| cmd.strip_prefix("/bin/bash -lc "))
+                            .unwrap_or(cmd)
+                            .trim_matches('\'')
+                            .trim_matches('"');
+                        events.push(ClaudeEvent::ToolUse {
+                            tool: "command".to_string(),
+                            file_path: None,
+                            detail: Some(truncate(display_cmd, 80)),
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // item.completed — the main event type for Codex output
+        "item.completed" => {
+            let item = &json["item"];
+            let item_type = item["type"].as_str().unwrap_or("");
+
+            match item_type {
+                "agent_message" => {
+                    if let Some(text) = item["text"].as_str() {
+                        let trimmed = text.trim();
+                        if !trimmed.is_empty() {
+                            events.push(ClaudeEvent::Text(trimmed.to_string()));
+                        }
+                    }
+                }
+
+                "reasoning" => {
+                    if let Some(text) = item["text"].as_str() {
+                        let trimmed = text.trim();
+                        if !trimmed.is_empty() {
+                            events.push(ClaudeEvent::StreamingText(format!(
+                                "[reasoning] {}",
+                                trimmed
+                            )));
+                        }
+                    }
+                }
+
+                "command_execution" => {
+                    let cmd = item["command"].as_str().unwrap_or("command");
+                    let display_cmd = cmd
+                        .strip_prefix("/bin/zsh -lc ")
+                        .or_else(|| cmd.strip_prefix("/bin/bash -lc "))
+                        .unwrap_or(cmd)
+                        .trim_matches('\'')
+                        .trim_matches('"');
+                    let exit_code = item["exit_code"].as_i64().unwrap_or(-1);
+                    let output = item["aggregated_output"].as_str().unwrap_or("");
+
+                    // Emit as ToolUse so the pipeline sees the activity
+                    events.push(ClaudeEvent::ToolUse {
+                        tool: "command".to_string(),
+                        file_path: None,
+                        detail: Some(format!(
+                            "{} (exit {})",
+                            truncate(display_cmd, 60),
+                            exit_code
+                        )),
+                    });
+
+                    if !output.is_empty() {
+                        // Show truncated output
+                        let output_preview = truncate(output.trim(), 200);
+                        events.push(ClaudeEvent::ToolResult {
+                            tool: "command".to_string(),
+                            output: output_preview,
+                        });
+                    }
+                }
+
+                "file_change" => {
+                    if let Some(changes) = item["changes"].as_array() {
+                        for change in changes {
+                            let path = change["path"].as_str().unwrap_or("unknown");
+                            let kind = change["kind"].as_str().unwrap_or("modify");
+                            let filename = path.rsplit('/').next().unwrap_or(path);
+
+                            let tool_name = match kind {
+                                "add" => "Write",
+                                "delete" => "Delete",
+                                _ => "Edit",
+                            };
+
+                            events.push(ClaudeEvent::ToolUse {
+                                tool: tool_name.to_string(),
+                                file_path: Some(path.to_string()),
+                                detail: Some(format!("{} {}", kind, filename)),
+                            });
+                        }
+                    }
+                }
+
+                "error" => {
+                    let msg = item["text"]
+                        .as_str()
+                        .or_else(|| item["message"].as_str())
+                        .unwrap_or("Unknown Codex error");
+                    *final_success = false;
+                    events.push(ClaudeEvent::Error(msg.to_string()));
+                }
+
+                _ => {
+                    // Try to extract text from unknown item types
+                    if let Some(text) = item["text"].as_str() {
+                        let trimmed = text.trim();
+                        if !trimmed.is_empty() {
+                            events.push(ClaudeEvent::Text(trimmed.to_string()));
+                        }
+                    }
+                }
+            }
+        }
+
+        "turn.completed" => {
+            if let Some(usage) = json.get("usage") {
+                *total_input_tokens += usage["input_tokens"].as_i64().unwrap_or(0);
+                *total_output_tokens += usage["output_tokens"].as_i64().unwrap_or(0);
+                *total_cached_tokens += usage["cached_input_tokens"].as_i64().unwrap_or(0);
+            }
+            events.push(ClaudeEvent::Text(format!(
+                "Done — {} turns, {}+{} tokens",
+                current_turns, total_input_tokens, total_output_tokens
+            )));
+            events.push(ClaudeEvent::Result {
+                success: *final_success,
+            });
+        }
+
+        "turn.failed" => {
+            *final_success = false;
+            let msg = json["error"]["message"].as_str().unwrap_or("Turn failed");
+            events.push(ClaudeEvent::Error(msg.to_string()));
+            events.push(ClaudeEvent::Result { success: false });
+        }
+
+        "error" => {
+            *final_success = false;
+            let msg = json["message"]
+                .as_str()
+                .or_else(|| json["error"].as_str())
+                .unwrap_or("Codex error");
+            events.push(ClaudeEvent::Error(msg.to_string()));
+        }
+
+        _ => {}
+    }
+
+    events
+}
+
+fn truncate(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max_len])
+    }
+}
+
+fn expected_output_files_exist(project_dir: &str, mode: &str) -> bool {
+    let required_files: &[&str] = match mode {
+        "generate" => &[
+            "Source/PluginProcessor.h",
+            "Source/PluginProcessor.cpp",
+            "Source/FoundryLookAndFeel.h",
+            "Source/PluginEditor.h",
+            "Source/PluginEditor.cpp",
+        ],
+        "generate_processor" => &["Source/PluginProcessor.h", "Source/PluginProcessor.cpp"],
+        "generate_ui" => &[
+            "Source/FoundryLookAndFeel.h",
+            "Source/PluginEditor.h",
+            "Source/PluginEditor.cpp",
+        ],
+        _ => &[],
+    };
+
+    if required_files.is_empty() {
+        return false;
+    }
+
+    let root = Path::new(project_dir);
+    required_files
+        .iter()
+        .all(|relative| root.join(relative).exists())
+}
+
+/// Map pipeline mode to system instructions baked into the prompt for Codex.
+fn mode_system_instructions(mode: &str) -> &'static str {
+    match mode {
+        "plan" => concat!(
+            "SPEED IS CRITICAL. Produce a short, visible planning pass immediately.\n",
+            "Respond with a concise implementation plan in 3-6 bullets.\n",
+            "Cover only: DSP architecture, parameter list, and UI structure.\n",
+            "Do NOT use any tools. Do NOT read or write files. Stop after the plan."
+        ),
+        "generate" => concat!(
+            "SPEED IS CRITICAL, but the first pass must still be compile-oriented.\n",
+            "Start with one short progress note describing DSP architecture, interaction concept, and UI structure.\n",
+            "The prompt contains ALL the information you need — do NOT read any files.\n",
+            "Turn 1: Immediately create Source/PluginProcessor.h and Source/PluginProcessor.cpp.\n",
+            "Turn 2: Create Source/FoundryLookAndFeel.h, Source/PluginEditor.h, and Source/PluginEditor.cpp.\n",
+            "Turn 3: Only if necessary, make one targeted edit pass.\n",
+            "Use shell write commands immediately when you create files; do not wait for a separate file tool.\n",
+            "Prefer distinctive control hierarchy over a generic row of knobs.\n",
+            "Do NOT verify your work with Read calls. Trust the prompt and write decisively.\n",
+            "Never respond with only text — always use tools after the initial sentence."
+        ),
+        "generate_processor" => concat!(
+            "SPEED IS CRITICAL, and observability matters.\n",
+            "Start with one short sentence describing the DSP/processor work you are about to do.\n",
+            "The prompt contains ALL the information you need — do NOT read any files.\n",
+            "Create ONLY Source/PluginProcessor.h and Source/PluginProcessor.cpp.\n",
+            "Use shell write commands immediately to create those files, for example with heredoc redirects.\n",
+            "If needed, make one final targeted edit pass.\n",
+            "Do NOT create editor or look-and-feel files in this phase.\n",
+            "Do NOT verify your work with Read calls. Trust your output.\n",
+            "Never respond with only text — always use tools after the initial sentence."
+        ),
+        "generate_ui" => concat!(
+            "SPEED IS CRITICAL, and observability matters.\n",
+            "Start with one short sentence describing the UI work you are about to do.\n",
+            "The prompt contains the parameter manifest and class names you need — do NOT read any files.\n",
+            "Immediately create Source/FoundryLookAndFeel.h, Source/PluginEditor.h, and Source/PluginEditor.cpp.\n",
+            "Use shell write commands immediately for missing files and edit only if needed.\n",
+            "Keep the editor landscape, aligned, and non-overlapping.\n",
+            "Do NOT modify CMakeLists.txt.\n",
+            "Do NOT rewrite processor files unless absolutely necessary.\n",
+            "Never respond with only text — always use tools after the initial sentence."
+        ),
+        "repair_generation" => concat!(
+            "RECOVERY MODE. Fix the generated Source/ tree quickly and decisively.\n",
+            "Start with one short sentence describing the repair you are about to make.\n",
+            "Read existing Source/ files first if they exist, then repair or create what is missing.\n",
+            "You MAY fully rewrite a broken Source/ file if that is faster and safer than patching it.\n",
+            "Only touch Source/ files. Do NOT modify CMakeLists.txt.\n",
+            "Never respond with only text — always use tools after the initial sentence."
+        ),
+        "refine" => concat!(
+            "SPEED IS CRITICAL. Minimize the number of turns.\n",
+            "Before using any tool, briefly state what you are about to do in one sentence.\n",
+            "Turn 1: Read ALL existing Source/ files.\n",
+            "Turn 2+: Make targeted changes — do NOT rewrite entire files.\n",
+            "Only modify what is necessary to fulfill the user's request. Keep everything else intact.\n",
+            "Never respond with only text — always use tools."
+        ),
+        "quality_audit" => concat!(
+            "QUALITY IS THE PRIORITY.\n",
+            "Start with one short sentence describing what you are auditing.\n",
+            "Turn 1: Read ALL existing Source/ files.\n",
+            "Turn 2+: Improve sound quality, parameter usefulness, and audible impact with targeted edits.\n",
+            "Requirements:\n",
+            "- No dead knobs: every exposed parameter must audibly affect the result.\n",
+            "- Instruments must sound good immediately at default settings on first MIDI note.\n",
+            "- Effects must produce a clearly audible effect at meaningful settings.\n",
+            "- Use proper gain staging and avoid outputs that are too quiet.\n",
+            "- Keep class names and parameter IDs stable.\n",
+            "Do NOT touch CMakeLists.txt.\n",
+            "Never respond with only text — always use tools."
+        ),
+        _ => concat!(
+            "SPEED IS CRITICAL, but observability matters too.\n",
+            "Start with a very short progress message describing your implementation plan in 2-4 bullets.\n",
+            "The prompt contains ALL the information you need — do NOT read any files.\n",
+            "Turn 1: Immediately create Source/PluginProcessor.h and Source/PluginProcessor.cpp.\n",
+            "Turn 2: Create Source/PluginEditor.h, Source/PluginEditor.cpp, and Source/FoundryLookAndFeel.h.\n",
+            "Turn 3: Only if you made an error, fix it. Otherwise, STOP.\n",
+            "Do NOT verify your work with Read calls. Trust your output.\n",
+            "Before each batch of tool calls, briefly say what you are about to do.\n",
+            "Never respond with only text — always use tools."
+        ),
+    }
+}
+
+/// Map pipeline mode to a max turns string (used for local enforcement).
+fn mode_max_turns(mode: &str) -> &'static str {
+    match mode {
+        "plan" => "2",
+        "generate" => "5",
+        "generate_processor" => "4",
+        "generate_ui" | "repair_generation" => "5",
+        "refine" | "quality_audit" => "6",
+        _ => "6",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expected_output_files_exist;
+
+    fn make_temp_dir() -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("foundry-codex-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(dir.join("Source")).unwrap();
+        dir
+    }
+
+    #[test]
+    fn generate_processor_requires_both_processor_files() {
+        let dir = make_temp_dir();
+        std::fs::write(dir.join("Source/PluginProcessor.h"), "// header").unwrap();
+        assert!(!expected_output_files_exist(
+            dir.to_str().unwrap(),
+            "generate_processor"
+        ));
+
+        std::fs::write(dir.join("Source/PluginProcessor.cpp"), "// source").unwrap();
+        assert!(expected_output_files_exist(
+            dir.to_str().unwrap(),
+            "generate_processor"
+        ));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/src-tauri/src/services/generation_pipeline.rs
+++ b/src-tauri/src/services/generation_pipeline.rs
@@ -7,8 +7,8 @@ use crate::models::config::{GenerationConfig, RefineConfig};
 use crate::models::plugin::{InstallPaths, Plugin, PluginFormat, PluginVersion};
 use crate::models::telemetry::TelemetryBuilder;
 use crate::services::{
-    build_environment, build_runner, claude_code_service, foundry_paths, plugin_manager,
-    project_assembler, telemetry_service,
+    agent_service, build_environment, build_runner, claude_code_service, foundry_paths,
+    plugin_manager, project_assembler, telemetry_service,
 };
 
 #[derive(Clone, serde::Serialize)]
@@ -126,9 +126,14 @@ async fn execute_generation(
     cancel_watch: tokio::sync::watch::Receiver<bool>,
     tb: &mut TelemetryBuilder,
 ) -> Result<Plugin, String> {
-    // Resolve Claude CLI path
-    let claude_path = claude_code_service::resolve_claude_path().ok_or_else(|| {
-        "Claude Code CLI is not available. Open Setup and install it.".to_string()
+    // Resolve agent CLI path (Claude Code or Codex)
+    let agent_name = &config.agent;
+    let agent_display = agent_service::agent_display_name(agent_name);
+    let cli_path = agent_service::resolve_agent_path(agent_name).ok_or_else(|| {
+        format!(
+            "{} CLI is not available. Open Setup and install it.",
+            agent_display
+        )
     })?;
 
     let model_flag = &config.model;
@@ -199,7 +204,11 @@ async fn execute_generation(
 
     emit_log(
         app,
-        &format!("── claude · {}: DSP pass ──", model_flag),
+        &format!(
+            "── {} · {}: DSP pass ──",
+            agent_display.to_lowercase(),
+            model_flag
+        ),
         Some("active"),
     );
     let processor_prompt = build_fast_processor_prompt(
@@ -212,8 +221,9 @@ async fn execute_generation(
     );
 
     let app_clone = app.clone();
-    let processor_result = claude_code_service::run(
-        &claude_path,
+    let processor_result = agent_service::run(
+        agent_name,
+        &cli_path,
         &processor_prompt,
         &project_dir_str,
         model_flag,
@@ -238,10 +248,61 @@ async fn execute_generation(
             .unwrap_or_else(|| "Claude Code CLI is unavailable".into()));
     }
 
-    let processor_missing: Vec<&str> = ["Source/PluginProcessor.h", "Source/PluginProcessor.cpp"]
-        .into_iter()
-        .filter(|path| !project.directory.join(path).exists())
-        .collect();
+    let mut processor_missing: Vec<&str> =
+        ["Source/PluginProcessor.h", "Source/PluginProcessor.cpp"]
+            .into_iter()
+            .filter(|path| !project.directory.join(path).exists())
+            .collect();
+
+    if !processor_missing.is_empty() {
+        emit_log(
+            app,
+            &format!(
+                "DSP pass incomplete — attempting recovery before UI pass. Missing: {}",
+                processor_missing.join(", ")
+            ),
+            Some("active"),
+        );
+
+        let repair_prompt = build_generation_repair_prompt(
+            &plugin_name,
+            plugin_role,
+            &config.prompt,
+            &config.channel_layout,
+            &processor_missing,
+            &[],
+        );
+
+        let app_clone = app.clone();
+        let repair_result = agent_service::run(
+            agent_name,
+            &cli_path,
+            &repair_prompt,
+            &project_dir_str,
+            model_flag,
+            "repair_generation",
+            move |event| handle_claude_event(&app_clone, &event),
+            cancel_watch.clone(),
+        )
+        .await;
+
+        tb.accumulate_run(&repair_result);
+
+        if is_infra_failure(&repair_result.error) {
+            tb.fail(
+                "generation",
+                repair_result.error.as_deref().unwrap_or("CLI unavailable"),
+            );
+            return Err(repair_result
+                .error
+                .unwrap_or_else(|| "Claude Code CLI is unavailable".into()));
+        }
+
+        processor_missing = ["Source/PluginProcessor.h", "Source/PluginProcessor.cpp"]
+            .into_iter()
+            .filter(|path| !project.directory.join(path).exists())
+            .collect();
+    }
 
     if !processor_missing.is_empty() {
         let message = format!(
@@ -257,7 +318,11 @@ async fn execute_generation(
     emit_step(app, "generatingUI");
     emit_log(
         app,
-        &format!("── claude · {}: UI pass ──", model_flag),
+        &format!(
+            "── {} · {}: UI pass ──",
+            agent_display.to_lowercase(),
+            model_flag
+        ),
         Some("active"),
     );
     let parameter_manifest = extract_parameter_manifest(&project.directory);
@@ -272,8 +337,9 @@ async fn execute_generation(
     );
 
     let app_clone = app.clone();
-    let mut ui_result = claude_code_service::run(
-        &claude_path,
+    let mut ui_result = agent_service::run(
+        agent_name,
+        &cli_path,
         &ui_prompt,
         &project_dir_str,
         model_flag,
@@ -296,8 +362,9 @@ async fn execute_generation(
         let emergency_ui_prompt =
             build_emergency_ui_prompt(&plugin_name, &parameter_manifest, &creative_profile);
         let app_clone = app.clone();
-        ui_result = claude_code_service::run(
-            &claude_path,
+        ui_result = agent_service::run(
+            agent_name,
+            &cli_path,
             &emergency_ui_prompt,
             &project_dir_str,
             model_flag,
@@ -354,8 +421,9 @@ async fn execute_generation(
         );
 
         let app_clone = app.clone();
-        let repair_result = claude_code_service::run(
-            &claude_path,
+        let repair_result = agent_service::run(
+            agent_name,
+            &cli_path,
             &repair_prompt,
             &project_dir_str,
             model_flag,
@@ -412,7 +480,8 @@ async fn execute_generation(
     tb.start_build();
 
     run_build_loop(
-        &claude_path,
+        agent_name,
+        &cli_path,
         &project.directory,
         model_flag,
         app,
@@ -562,8 +631,14 @@ async fn execute_refine(
     cancel_watch: tokio::sync::watch::Receiver<bool>,
     tb: &mut TelemetryBuilder,
 ) -> Result<Plugin, String> {
-    let claude_path = claude_code_service::resolve_claude_path()
-        .ok_or_else(|| "Claude Code CLI is not available".to_string())?;
+    // Resolve agent CLI — refine uses the agent that built the original plugin
+    let refine_agent = match &config.plugin.agent {
+        Some(crate::models::agent::GenerationAgent::Codex) => "Codex",
+        _ => "Claude Code",
+    };
+    let refine_display = agent_service::agent_display_name(refine_agent);
+    let cli_path = agent_service::resolve_agent_path(refine_agent)
+        .ok_or_else(|| format!("{} CLI is not available", refine_display))?;
 
     let build_dir = config
         .plugin
@@ -637,8 +712,9 @@ async fn execute_refine(
     );
 
     let app_clone = app.clone();
-    let gen_result = claude_code_service::run(
-        &claude_path,
+    let gen_result = agent_service::run(
+        refine_agent,
+        &cli_path,
         &refine_prompt,
         build_dir,
         model_flag,
@@ -686,7 +762,8 @@ async fn execute_refine(
     tb.start_build();
 
     if let Err(e) = run_build_loop_with_skip(
-        &claude_path,
+        refine_agent,
+        &cli_path,
         project_dir,
         model_flag,
         app,
@@ -779,7 +856,8 @@ async fn execute_refine(
 // ---- Build Loop ----
 
 async fn run_build_loop(
-    claude_path: &str,
+    agent: &str,
+    cli_path: &str,
     project_dir: &Path,
     model_flag: &str,
     app: &AppHandle,
@@ -788,7 +866,8 @@ async fn run_build_loop(
     max_attempts: Option<i32>,
 ) -> Result<(), String> {
     run_build_loop_with_skip(
-        claude_path,
+        agent,
+        cli_path,
         project_dir,
         model_flag,
         app,
@@ -801,7 +880,8 @@ async fn run_build_loop(
 }
 
 async fn run_build_loop_with_skip(
-    claude_path: &str,
+    agent: &str,
+    cli_path: &str,
     project_dir: &Path,
     model_flag: &str,
     app: &AppHandle,
@@ -869,8 +949,9 @@ async fn run_build_loop_with_skip(
                 Some("error"),
             );
 
-            let fix_result = claude_code_service::fix(
-                claude_path,
+            let fix_result = agent_service::fix(
+                agent,
+                cli_path,
                 "Build succeeded but smoke test failed: plugin bundles are missing or invalid.",
                 &project_dir_str,
                 attempt,
@@ -933,8 +1014,9 @@ async fn run_build_loop_with_skip(
 
         let app_clone = app.clone();
         let project_dir_str = project_dir.to_string_lossy().to_string();
-        let fix_result = claude_code_service::fix(
-            claude_path,
+        let fix_result = agent_service::fix(
+            agent,
+            cli_path,
             &result.errors,
             &project_dir_str,
             attempt,
@@ -1387,6 +1469,11 @@ Rules:
 - Use FoundryLookAndFeel in the editor.
 - Avoid a flat row of generic knobs; create one hero interaction zone.
 - Prefer showing the 8-12 most important parameters if the processor exposes many internals.
+- Use a sane landscape editor size, typically around 760-920 px wide and 420-560 px tall.
+- Build the layout from `getLocalBounds().reduced(...)` plus `removeFrom*`, or use `juce::Grid` / `juce::FlexBox`; do not scatter arbitrary overlapping coordinates.
+- Keep outer padding around 20-28 px and internal gaps around 12-20 px.
+- Keep rotary controls square and readable, labels aligned, and widgets away from the window edges.
+- Make the interface clean and balanced before it is flashy.
 - Keep class name exactly {name}Editor.
 - Use juce:: prefixes everywhere.
 - Do not read files.
@@ -1445,7 +1532,9 @@ Rules:
 - No explanation after writing.
 - Use FoundryLookAndFeel.
 - Use APVTS attachments for every visible control.
-- Keep the UI compact and compile-safe.
+- Use a landscape editor size with a clean, non-overlapping layout.
+- Derive geometry from `getLocalBounds()` with consistent padding and gaps.
+- Keep the UI compact, legible, and compile-safe.
 "#,
         name = plugin_name,
         parameter_block = parameter_block,
@@ -1718,10 +1807,56 @@ fn validate_generated_source_tree(project_dir: &Path, plugin_name: &str) -> Vec<
     if !editor_header.contains("Attachment") && !editor_source.contains("Attachment") {
         issues.push("Editor must create APVTS attachments for controls".into());
     }
+    if let Some((width, height)) = extract_editor_size(&editor_source) {
+        if !(640..=1200).contains(&width) || !(360..=900).contains(&height) {
+            issues.push("Editor must use a reasonable fixed window size".into());
+        }
+        if width <= height {
+            issues.push(
+                "Editor should use a landscape window instead of a tall or square layout".into(),
+            );
+        }
+    } else {
+        issues.push("Editor must call setSize(...) with an explicit landscape window size".into());
+    }
+    if !uses_structured_editor_layout(&editor_source) {
+        issues.push(
+            "Editor must lay out controls from getLocalBounds() using reduced/removeFrom geometry, Grid, or FlexBox".into(),
+        );
+    }
 
     issues.sort();
     issues.dedup();
     issues
+}
+
+fn extract_editor_size(editor_source: &str) -> Option<(i32, i32)> {
+    let set_size_index = editor_source.find("setSize")?;
+    let after_call = &editor_source[set_size_index + "setSize".len()..];
+    let open_paren = after_call.find('(')?;
+    let args = &after_call[open_paren + 1..];
+    let comma = args.find(',')?;
+    let close_paren = args[comma + 1..].find(')')?;
+
+    let width: String = args[..comma]
+        .chars()
+        .filter(|ch| ch.is_ascii_digit())
+        .collect();
+    let height: String = args[comma + 1..comma + 1 + close_paren]
+        .chars()
+        .filter(|ch| ch.is_ascii_digit())
+        .collect();
+
+    Some((width.parse().ok()?, height.parse().ok()?))
+}
+
+fn uses_structured_editor_layout(editor_source: &str) -> bool {
+    let uses_bounds_flow = editor_source.contains("getLocalBounds()")
+        && (editor_source.contains("reduced(") || editor_source.contains("removeFrom"));
+
+    uses_bounds_flow
+        || editor_source.contains("juce::Grid")
+        || editor_source.contains("juce::FlexBox")
 }
 
 fn build_generation_repair_prompt(
@@ -1765,12 +1900,14 @@ Validation issues:
 {validation}
 
 Rules:
-- Read existing Source/ files first so your class names and APIs stay consistent.
+- Read existing Source/ files first if they exist so your class names and APIs stay consistent.
 - Create or repair only the required Source/ files.
 - Keep class names exactly `{name}Processor` and `{name}Editor`.
 - Keep parameter IDs stable whenever possible.
 - Every exposed control must have a matching APVTS attachment.
 - Ensure FoundryLookAndFeel is implemented and used by the editor.
+- UI must use a sane landscape editor size with consistent padding, spacing, and non-overlapping controls.
+- UI layout must come from `getLocalBounds()` flow, `juce::Grid`, or `juce::FlexBox`, not arbitrary scattered coordinates.
 - Remove any leftover `FoundryPlugin` placeholder text.
 - Do not touch CMakeLists.txt.
 
@@ -1942,6 +2079,54 @@ mod tests {
             .iter()
             .any(|issue| issue.contains("FoundryLookAndFeel")));
         assert!(issues.iter().any(|issue| issue.contains("attachments")));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn extract_editor_size_reads_numeric_dimensions() {
+        assert_eq!(extract_editor_size("setSize (820, 480);"), Some((820, 480)));
+    }
+
+    #[test]
+    fn validation_reports_deformed_or_unstructured_ui() {
+        let dir = make_temp_dir();
+
+        std::fs::write(
+            dir.join("Source/PluginProcessor.h"),
+            "#include <JuceHeader.h>\nclass FluxProcessor { public: juce::AudioProcessorValueTreeState apvts; };",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("Source/PluginProcessor.cpp"),
+            "#include \"PluginProcessor.h\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("Source/PluginEditor.h"),
+            "#include <JuceHeader.h>\nclass FluxEditor { class FoundryLookAndFeel* lnf; using SliderAttachment = juce::AudioProcessorValueTreeState::SliderAttachment; };",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("Source/PluginEditor.cpp"),
+            "#include \"PluginEditor.h\"\nvoid FluxEditor::resized() {}\nFluxEditor::FluxEditor() { setSize(320, 900); }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("Source/FoundryLookAndFeel.h"),
+            "#include <JuceHeader.h>\nclass FoundryLookAndFeel {};",
+        )
+        .unwrap();
+
+        let issues = validate_generated_source_tree(&dir, "Flux");
+
+        assert!(issues
+            .iter()
+            .any(|issue| issue.contains("reasonable fixed window size")));
+        assert!(issues
+            .iter()
+            .any(|issue| issue.contains("landscape window")));
+        assert!(issues.iter().any(|issue| issue.contains("getLocalBounds")));
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,13 +1,15 @@
+pub mod agent_service;
 pub mod auth_service;
 pub mod build_directory_cleaner;
 pub mod build_environment;
 pub mod build_runner;
 pub mod claude_code_service;
+pub mod codex_service;
 pub mod dependency_checker;
 pub mod foundry_paths;
 pub mod generation_pipeline;
 pub mod model_catalog;
+pub mod onboarding;
 pub mod plugin_manager;
 pub mod project_assembler;
-pub mod onboarding;
 pub mod telemetry_service;

--- a/src-tauri/src/services/model_catalog.rs
+++ b/src-tauri/src/services/model_catalog.rs
@@ -7,43 +7,108 @@ struct CatalogRoot {
     providers: Vec<AgentProvider>,
 }
 
+/// Known models for each provider. These are the models that the CLI accepts
+/// via `--model` / `-m`. Neither CLI exposes a "list models" command, so we
+/// maintain the list here and filter by which CLIs are actually installed.
+fn claude_code_models() -> Vec<AgentModel> {
+    vec![
+        AgentModel {
+            id: "sonnet".into(),
+            name: "Sonnet".into(),
+            subtitle: "Fast & capable".into(),
+            flag: "sonnet".into(),
+            default: Some(true),
+        },
+        AgentModel {
+            id: "opus".into(),
+            name: "Opus".into(),
+            subtitle: "Most capable".into(),
+            flag: "opus".into(),
+            default: None,
+        },
+        AgentModel {
+            id: "haiku".into(),
+            name: "Haiku".into(),
+            subtitle: "Fastest".into(),
+            flag: "haiku".into(),
+            default: None,
+        },
+    ]
+}
+
+fn codex_models() -> Vec<AgentModel> {
+    vec![
+        AgentModel {
+            id: "gpt-5.4".into(),
+            name: "GPT-5.4".into(),
+            subtitle: "Most capable".into(),
+            flag: "gpt-5.4".into(),
+            default: Some(true),
+        },
+        AgentModel {
+            id: "gpt-5.4-mini".into(),
+            name: "GPT-5.4 Mini".into(),
+            subtitle: "Fast & efficient".into(),
+            flag: "gpt-5.4-mini".into(),
+            default: None,
+        },
+        AgentModel {
+            id: "gpt-5.2-codex".into(),
+            name: "GPT-5.2 Codex".into(),
+            subtitle: "Optimized for code".into(),
+            flag: "gpt-5.2-codex".into(),
+            default: None,
+        },
+    ]
+}
+
+/// Build the catalog by detecting which CLIs are installed on this machine.
+fn detect_installed_providers() -> Vec<AgentProvider> {
+    let mut providers = Vec::new();
+
+    if crate::platform::resolve_claude_path().is_some() {
+        providers.push(AgentProvider {
+            id: "claude-code".into(),
+            name: "Claude Code".into(),
+            icon: "ProviderAnthropic".into(),
+            command: "claude".into(),
+            models: claude_code_models(),
+        });
+    }
+
+    if crate::platform::resolve_codex_path().is_some() {
+        providers.push(AgentProvider {
+            id: "codex".into(),
+            name: "Codex".into(),
+            icon: "ProviderOpenAI".into(),
+            command: "codex".into(),
+            models: codex_models(),
+        });
+    }
+
+    providers
+}
+
+/// Load the model catalog. Priority:
+/// 1. User override file (`models.json`) — full customization
+/// 2. Dynamic detection of installed CLIs (always fresh, always authoritative)
 pub fn load_catalog() -> Result<Vec<AgentProvider>, Box<dyn std::error::Error>> {
+    // User override takes precedence — allows full customization
     let user_path = foundry_paths::models_user_override_path();
     if user_path.exists() {
         let data = fs::read_to_string(&user_path)?;
         let root: CatalogRoot = serde_json::from_str(&data)?;
         return Ok(root.providers);
     }
-    let cache_path = foundry_paths::models_cache_path();
-    if cache_path.exists() {
-        let data = fs::read_to_string(&cache_path)?;
-        let root: CatalogRoot = serde_json::from_str(&data)?;
-        return Ok(root.providers);
-    }
-    Ok(vec![AgentProvider {
-        id: "claude-code".into(),
-        name: "Claude Code".into(),
-        icon: "ProviderAnthropic".into(),
-        command: "claude".into(),
-        models: vec![
-            AgentModel {
-                id: "sonnet".into(),
-                name: "Sonnet".into(),
-                subtitle: "Fast & capable".into(),
-                flag: "sonnet".into(),
-                default: Some(true),
-            },
-            AgentModel {
-                id: "opus".into(),
-                name: "Opus".into(),
-                subtitle: "Most capable".into(),
-                flag: "opus".into(),
-                default: None,
-            },
-        ],
-    }])
+
+    // Always detect installed CLIs — no stale cache
+    Ok(detect_installed_providers())
 }
 
+/// Refresh the catalog by re-detecting installed CLIs.
+/// Invalidates the shell cache first so newly installed tools are found.
 pub async fn refresh() -> Result<Vec<AgentProvider>, Box<dyn std::error::Error>> {
+    // Invalidate platform caches so we pick up newly installed CLIs
+    crate::platform::invalidate_shell_cache();
     load_catalog()
 }

--- a/src-tauri/src/services/onboarding.rs
+++ b/src-tauri/src/services/onboarding.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 use serde::{Deserialize, Serialize};
 
 use crate::platform;
-use crate::services::auth_service::{SupabaseAuth, SUPABASE_URL, SUPABASE_ANON_KEY};
+use crate::services::auth_service::{SupabaseAuth, SUPABASE_ANON_KEY, SUPABASE_URL};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -42,8 +42,7 @@ pub async fn get_onboarding_state(auth: &SupabaseAuth) -> OnboardingState {
     match resp {
         Ok(r) if r.status().is_success() => {
             let text = r.text().await.unwrap_or_default();
-            let rows: Vec<serde_json::Value> =
-                serde_json::from_str(&text).unwrap_or_default();
+            let rows: Vec<serde_json::Value> = serde_json::from_str(&text).unwrap_or_default();
             if let Some(row) = rows.first() {
                 let completed_at = row
                     .get("onboarding_completed_at")

--- a/src-tauri/src/services/project_assembler.rs
+++ b/src-tauri/src/services/project_assembler.rs
@@ -131,6 +131,15 @@ pub fn assemble(
         prompt,
         channel_layout,
     )?;
+    // Codex reads AGENTS.md instead of CLAUDE.md — write both so either agent works.
+    write_agents_md(
+        &project_dir,
+        plugin_name,
+        &plugin_type,
+        interface_style,
+        prompt,
+        channel_layout,
+    )?;
 
     Ok(AssembledProject {
         directory: project_dir,
@@ -235,15 +244,15 @@ Build a JUCE {role} plugin: {prompt}
 ## Interface Direction
 {style} — adjust the number and complexity of controls accordingly.
 
-## Files to Create
+## Source Files
 - Source/PluginProcessor.h
 - Source/PluginProcessor.cpp
 - Source/PluginEditor.h
 - Source/PluginEditor.cpp
 - Source/FoundryLookAndFeel.h
 
-## Knowledge Kit
-Read these reference files for API patterns and build rules:
+## Reference Kit
+Optional reference files for API patterns and build rules:
 - juce-kit/juce-api.md
 - juce-kit/dsp-patterns.md
 - juce-kit/ui-patterns.md
@@ -251,10 +260,18 @@ Read these reference files for API patterns and build rules:
 - juce-kit/build-rules.md
 - juce-kit/presets.md
 
+## Phase Rules
+- The orchestration prompt is phase-aware and authoritative.
+- If the prompt asks only for processor files, create only `Source/PluginProcessor.h` and `Source/PluginProcessor.cpp`.
+- If the prompt asks only for UI files, create only `Source/FoundryLookAndFeel.h`, `Source/PluginEditor.h`, and `Source/PluginEditor.cpp`.
+- Do not create files outside the current phase unless the prompt explicitly asks for them.
+- If the prompt says it is self-contained or says not to read files, skip the reference kit.
+- Use the reference kit only when the prompt explicitly needs extra context.
+
 ## Workflow
-1. Read this file + all juce-kit/*.md files in PARALLEL
-2. Write all 5 source files using PARALLEL Write calls
-3. Do NOT verify — trust your output
+1. Follow the current prompt exactly.
+2. Write the requested files immediately instead of waiting for a full-plan dump.
+3. Stop when the requested phase is complete.
 
 ## Design Principles
 - Every parameter uses AudioProcessorValueTreeState (APVTS)
@@ -275,6 +292,87 @@ Make it sound and look professional. The plugin should feel like a premium comme
     );
 
     fs::write(dir.join("CLAUDE.md"), content).map_err(|e| e.to_string())
+}
+
+/// Write AGENTS.md — the Codex equivalent of CLAUDE.md.
+/// Same content, different filename so the Codex CLI picks it up automatically.
+fn write_agents_md(
+    dir: &Path,
+    name: &str,
+    plugin_type: &str,
+    interface_style: &str,
+    prompt: &str,
+    channel_layout: &str,
+) -> Result<(), String> {
+    let plugin_role = match plugin_type {
+        "instrument" => "playable instrument",
+        "utility" => "utility or analysis tool",
+        _ => "audio effect",
+    };
+
+    let content = format!(
+        r#"# {name} — JUCE Plugin
+
+## Mission
+Build a JUCE {role} plugin: {prompt}
+
+## Plugin Type
+{plugin_type}
+
+## Channel Layout
+{channels}
+
+## Interface Direction
+{style} — adjust the number and complexity of controls accordingly.
+
+## Source Files
+- Source/PluginProcessor.h
+- Source/PluginProcessor.cpp
+- Source/PluginEditor.h
+- Source/PluginEditor.cpp
+- Source/FoundryLookAndFeel.h
+
+## Reference Kit
+Optional reference files for API patterns and build rules:
+- juce-kit/juce-api.md
+- juce-kit/dsp-patterns.md
+- juce-kit/ui-patterns.md
+- juce-kit/look-and-feel.md
+- juce-kit/build-rules.md
+- juce-kit/presets.md
+
+## Phase Rules
+- The orchestration prompt is phase-aware and authoritative.
+- If the prompt asks only for processor files, create only `Source/PluginProcessor.h` and `Source/PluginProcessor.cpp`.
+- If the prompt asks only for UI files, create only `Source/FoundryLookAndFeel.h`, `Source/PluginEditor.h`, and `Source/PluginEditor.cpp`.
+- Do not create files outside the current phase unless the prompt explicitly asks for them.
+- If the prompt says it is self-contained or says not to read files, skip the reference kit.
+- Use the reference kit only when the prompt explicitly needs extra context.
+
+## Workflow
+1. Follow the current prompt exactly.
+2. Write the requested files immediately instead of waiting for a full-plan dump.
+3. Stop when the requested phase is complete.
+
+## Design Principles
+- Every parameter uses AudioProcessorValueTreeState (APVTS)
+- Every UI control has a matching Attachment (SliderAttachment, ComboBoxAttachment, ButtonAttachment)
+- All JUCE types use juce:: prefix
+- FoundryLookAndFeel customizes the visual appearance
+- C++17, no auto* parameters, .h/.cpp signatures must match
+
+## Creative Direction
+Make it sound and look professional. The plugin should feel like a premium commercial product.
+"#,
+        name = name,
+        role = plugin_role,
+        prompt = prompt,
+        plugin_type = plugin_type,
+        channels = channel_layout,
+        style = interface_style,
+    );
+
+    fs::write(dir.join("AGENTS.md"), content).map_err(|e| e.to_string())
 }
 
 fn write_juce_kit(dir: &Path, plugin_name: &str, plugin_type: &str) -> Result<(), String> {
@@ -421,6 +519,13 @@ auto bounds = getLocalBounds().reduced(20);
 auto topArea = bounds.removeFromTop(bounds.getHeight() / 2);
 gainSlider.setBounds(topArea.removeFromLeft(topArea.getWidth() / 2).reduced(10));
 ```
+
+## Layout Quality Rules
+- Prefer a landscape editor around 760x460 to 920x560 unless the brief explicitly needs something else
+- Start from `getLocalBounds().reduced(20-28)` and keep consistent 12-20 px gaps
+- Split the UI into clear zones: header, hero control area, secondary controls/footer
+- Keep rotary controls square and readable; avoid stretched knobs, clipped labels, or controls touching the edges
+- Use `removeFromTop/Left/Right/Bottom`, `juce::Grid`, or `juce::FlexBox` instead of scattered absolute coordinates
 "#;
     fs::write(dir.join("ui-patterns.md"), content).map_err(|e| e.to_string())
 }
@@ -454,6 +559,11 @@ Override `drawRotarySlider()` for custom knobs. Common styles:
 - Arc style: draw background arc + value arc
 - Filled dot: circle at value position on arc
 - Minimal: just a line indicator
+
+### Visual Restraint
+- Keep the palette tight: one background family, one accent family, and high-contrast text
+- Use clear section hierarchy before decoration
+- Avoid overdesigned gradients, noisy shadows, and cramped typography
 
 ### Font Constructor
 ALWAYS use: `juce::Font(juce::FontOptions(fontSize))`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,6 +137,7 @@ export default function App() {
   const checkOnboarding = useAppStore((s) => s.checkOnboarding)
   const initTheme = useSettingsStore((s) => s.initTheme)
   const loadBuildEnvironment = useSettingsStore((s) => s.loadBuildEnvironment)
+  const loadCatalog = useSettingsStore((s) => s.loadCatalog)
 
   useEffect(() => {
     initTheme()
@@ -145,6 +146,10 @@ export default function App() {
   useEffect(() => {
     loadBuildEnvironment()
   }, [loadBuildEnvironment])
+
+  useEffect(() => {
+    loadCatalog()
+  }, [loadCatalog])
 
   useEffect(() => {
     checkSession()

--- a/src/pages/Prompt.tsx
+++ b/src/pages/Prompt.tsx
@@ -41,6 +41,7 @@ export default function Prompt() {
   const startGeneration = useBuildStore((s) => s.startGeneration);
   const modelCatalog = useSettingsStore((s) => s.modelCatalog);
   const [prompt, setPrompt] = useState("");
+  const [selectedAgent, setSelectedAgent] = useState("Claude Code");
   const [selectedModel, setSelectedModel] = useState("sonnet");
   const [showModelMenu, setShowModelMenu] = useState(false);
 
@@ -54,7 +55,7 @@ export default function Prompt() {
       format: "Both",
       channelLayout: "Stereo",
       presetCount: 5,
-      agent: "Claude Code",
+      agent: selectedAgent,
       model: selectedModel,
     });
   };
@@ -101,19 +102,17 @@ export default function Prompt() {
                 <>
                   <div className="fixed inset-0 z-10" onClick={() => setShowModelMenu(false)} />
                   <div className="absolute top-full left-0 mt-1 bg-card border border-border rounded-md shadow-xl z-20 min-w-[200px]">
-                    {(modelCatalog.length > 0 ? modelCatalog : [{
-                      id: "claude-code", name: "Claude Code", icon: "", command: "claude",
-                      models: [
-                        { id: "sonnet", name: "Sonnet", subtitle: "Fast & capable", flag: "sonnet", default: true },
-                        { id: "opus", name: "Opus", subtitle: "Most capable", flag: "opus" },
-                      ]
-                    }]).map((provider) => (
+                    {modelCatalog.length === 0 ? (
+                      <div className="px-3 py-3 text-[11px] text-muted-foreground">
+                        No agent CLI installed. Open Setup to install Claude Code or Codex.
+                      </div>
+                    ) : modelCatalog.map((provider) => (
                       <div key={provider.id}>
                         <div className="px-3 py-1.5 text-[9px] tracking-[1px] text-muted-foreground/60 uppercase">{provider.name}</div>
                         {provider.models.map((model) => (
                           <button
                             key={model.id}
-                            onClick={() => { setSelectedModel(model.flag || model.id); setShowModelMenu(false); }}
+                            onClick={() => { setSelectedAgent(provider.name); setSelectedModel(model.flag || model.id); setShowModelMenu(false); }}
                             className={`w-full px-3 py-2 text-left text-[12px] hover:bg-secondary flex items-center gap-2 ${
                               selectedModel === (model.flag || model.id) ? "text-primary" : ""
                             }`}

--- a/src/pages/quick-options.tsx
+++ b/src/pages/quick-options.tsx
@@ -9,6 +9,8 @@ export default function QuickOptions() {
   const location = useLocation();
   const startGeneration = useBuildStore((s) => s.startGeneration);
   const prompt = (location.state as any)?.prompt || "";
+  const agent = (location.state as any)?.agent || "Claude Code";
+  const model = (location.state as any)?.model || "sonnet";
 
   const [format, setFormat] = useState<FormatOption>("Both");
   const [channels, setChannels] = useState<ChannelLayout>("Stereo");
@@ -20,8 +22,8 @@ export default function QuickOptions() {
       format,
       channelLayout: channels,
       presetCount: presets,
-      agent: "Claude Code",
-      model: "sonnet",
+      agent,
+      model,
     });
     navigate("/generation");
   };


### PR DESCRIPTION
## Summary
- **Unified agent dispatcher** (`agent_service.rs`): routes generation calls to Claude Code or Codex based on user selection — pipeline is now backend-agnostic
- **Codex JSONL parser** (`codex_service.rs`): handles real Codex event types (`item.started`, `item.completed` with `command_execution`, `file_change`, `agent_message`, `reasoning`)
- **Critical fix**: Codex hangs with `Stdio::null()` — switched to `Stdio::piped()` + immediate `drop()` for proper EOF
- **Dynamic model catalog**: detects installed CLIs at runtime, exposes correct models (sonnet/opus/haiku for Claude, gpt-5.4/gpt-5.4-mini/gpt-5.2-codex for Codex)
- **Generation repair pass**: automatic retry when DSP pass doesn't produce expected files
- **Platform**: `resolve_codex_path()` added for macOS, Linux, Windows

## Test plan
- [ ] Select Codex as agent in the prompt page → verify model dropdown shows GPT-5.4 models
- [ ] Generate a plugin with Codex → verify terminal shows real-time events (commands, file changes)
- [ ] Generate a plugin with Claude Code → verify no regression
- [ ] Uninstall Codex CLI → verify only Claude Code appears in provider list
- [ ] Trigger DSP pass failure → verify repair pass kicks in automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)