### PR TITLE
Prepare Windows support

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,41 @@
+name: Validate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  desktop-checks:
+    name: Desktop Checks (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Check Tauri backend
+        working-directory: src-tauri
+        run: cargo check

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -1,0 +1,40 @@
+name: Build Windows Package
+
+on:
+  workflow_dispatch:
+
+jobs:
+  package-windows:
+    name: Package Windows Installers
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Build Windows installers
+        run: npm run tauri -- build --config src-tauri/tauri.windows.conf.json
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: foundry-windows-installers
+          path: |
+            src-tauri/target/release/bundle/nsis/**
+            src-tauri/target/release/bundle/msi/**
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Generate audio plugins from a sentence.**
 
-Foundry is a macOS app that turns a natural language description into a real, installable AU/VST3 plugin — compiled locally, no code required.
+Foundry is a desktop app for macOS and Windows that turns a natural language description into a real, installable plugin — compiled locally, no code required.
 
 > "A warm tape saturation with drive and tone controls"  
 > "A polyphonic pad synth with lush reverb and 5 presets"  
@@ -15,11 +15,11 @@ Foundry writes the C++, builds it with JUCE, and installs it directly into your 
 ## How it works
 
 1. **Describe** your plugin in plain language
-2. **Choose** format (AU / VST3 / both), stereo or mono, number of presets
+2. **Generate** the platform-supported plugin format automatically (AU/VST3 on macOS, VST3 on Windows)
 3. **Wait** ~2–5 minutes while Foundry generates and compiles
-4. **Open** the plugin in any AU/VST3-compatible DAW
+4. **Open** the plugin in any compatible DAW
 
-Under the hood: Claude Code CLI writes the JUCE C++ code, CMake builds it, and Foundry installs it to `/Library/Audio/Plug-Ins/`.
+Under the hood: Claude Code CLI writes the JUCE C++ code, CMake builds it, and Foundry installs it to the correct platform plugin directory.
 
 ---
 
@@ -27,11 +27,9 @@ Under the hood: Claude Code CLI writes the JUCE C++ code, CMake builds it, and F
 
 | Dependency | How to install |
 |---|---|
-| macOS 13+ (Apple Silicon recommended) | — |
-| Xcode Command Line Tools | `xcode-select --install` |
-| CMake | `brew install cmake` |
-| Claude Code CLI | `npm install -g @anthropic-ai/claude-code` |
-| JUCE SDK | Downloaded automatically on first launch |
+| macOS 13+ | Xcode Command Line Tools, CMake, Claude Code CLI, managed JUCE install |
+| Windows 11+ | Visual Studio 2022 Build Tools (Desktop C++), CMake, Claude Code CLI, managed JUCE install |
+| Optional | Codex CLI (`npm install -g @openai/codex`) |
 
 ---
 
@@ -39,7 +37,7 @@ Under the hood: Claude Code CLI writes the JUCE C++ code, CMake builds it, and F
 
 - **Three plugin archetypes** — instrument, effect, utility — Claude writes each from scratch using expert JUCE knowledge
 - **Refine** — modify an existing generated plugin with a follow-up instruction without starting from scratch
-- **Plugin logo generation** — generate a custom logo image for any plugin using local Stable Diffusion (Apple CoreML, no cloud)
+- **Plugin logo generation** — generate a custom logo image for any plugin using local Stable Diffusion
 - **Plugin Library** — browse, manage, and re-open all generated plugins
 - **FoundryLookAndFeel** — consistent dark minimal design system across every generated plugin UI
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foundry-tauri",
-  "version": "1.0.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foundry-tauri",
-      "version": "1.0.0",
+      "version": "1.17.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@fontsource-variable/geist": "^5.2.8",

--- a/setup.sh
+++ b/setup.sh
@@ -22,7 +22,7 @@ check_cmd "node"    "https://nodejs.org"
 check_cmd "npm"     "comes with Node.js"
 check_cmd "rustc"   "https://rustup.rs"
 check_cmd "cargo"   "https://rustup.rs"
-check_cmd "cmake"   "brew install cmake"
+check_cmd "cmake"   "Install CMake from https://cmake.org/download/ or your platform package manager"
 echo ""
 
 # ------------------------------------------------------------------
@@ -31,6 +31,21 @@ echo ""
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ENV_FILE="$SCRIPT_DIR/.env"
 ENV_EXAMPLE="$SCRIPT_DIR/.env.example"
+
+open_in_editor() {
+  local file="$1"
+  if [ -n "$EDITOR" ]; then
+    "$EDITOR" "$file"
+  elif command -v open >/dev/null 2>&1; then
+    open "$file"
+  elif command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$file"
+  elif command -v cmd.exe >/dev/null 2>&1; then
+    cmd.exe /C start "" "$(cygpath -w "$file" 2>/dev/null || echo "$file")"
+  else
+    echo "Open the file manually: $file"
+  fi
+}
 
 if [ -f "$ENV_FILE" ]; then
   echo "✅ .env file already exists"
@@ -45,7 +60,7 @@ else
     read -p "Open .env in your editor now? [Y/n] " -n 1 -r
     echo
     if [[ ! $REPLY =~ ^[Nn]$ ]]; then
-      ${EDITOR:-open} "$ENV_FILE"
+      open_in_editor "$ENV_FILE"
     fi
   else
     echo "❌ .env.example not found"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -76,6 +76,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +695,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "foundry"
-version = "1.15.0"
+version = "1.17.0"
 dependencies = [
  "chrono",
  "cocoa",
@@ -1058,6 +1078,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tokio",
  "uuid",
+ "zip",
 ]
 
 [[package]]
@@ -5960,7 +5981,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,4 +30,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6"
 dotenvy = "0.15"
+zip = { version = "2", default-features = false, features = ["deflate"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.26"

--- a/src-tauri/src/commands/onboarding.rs
+++ b/src-tauri/src/commands/onboarding.rs
@@ -24,6 +24,7 @@ pub async fn install_dependency(
 ) -> Result<onboarding::DependencyInstallResult, String> {
     let result = tokio::task::spawn_blocking(move || match name.as_str() {
         "xcode_clt" => onboarding::install_xcode_clt(),
+        "cpp_build_tools" => onboarding::install_cpp_build_tools(),
         "cmake" => onboarding::install_cmake(),
         "claude_code" => onboarding::install_claude_code(),
         "codex" => onboarding::install_codex(),

--- a/src-tauri/src/commands/plugins.rs
+++ b/src-tauri/src/commands/plugins.rs
@@ -64,61 +64,46 @@ pub async fn install_version(
         return Err(format!("Build directory does not exist: {}", build_dir));
     }
 
-    // Resolve install directories (respects user overrides)
-    let au_dir = platform::plugin_install_dir(&PluginFormat::Au);
-    let vst3_dir = platform::plugin_install_dir(&PluginFormat::Vst3);
-    let au_dest = &au_dir.path;
-    let vst3_dest = &vst3_dir.path;
-
     let mut new_install_paths = crate::models::plugin::InstallPaths::default();
+    let mut operations = Vec::new();
 
-    // Search for .component bundles in build directory
-    if let Ok(entries) = find_bundles(build_path, "component") {
-        for bundle_path in entries {
-            let bundle_name = bundle_path
-                .file_name()
-                .ok_or_else(|| "Invalid bundle name".to_string())?;
-            let dest = au_dest.join(bundle_name);
+    for mapping in platform::bundle_mappings() {
+        let plugin_format = match mapping.format_label {
+            "AU" => PluginFormat::Au,
+            "VST3" => PluginFormat::Vst3,
+            _ => continue,
+        };
 
-            // Remove existing bundle if present
-            if dest.exists() {
-                std::fs::remove_dir_all(&dest)
-                    .map_err(|e| format!("Failed to remove existing AU: {}", e))?;
+        let extension = mapping.extension.trim_start_matches('.');
+        if let Ok(entries) = find_bundles(build_path, extension) {
+            for bundle_path in entries {
+                let bundle_name = bundle_path
+                    .file_name()
+                    .ok_or_else(|| "Invalid bundle name".to_string())?;
+                let install_dir = platform::plugin_install_dir(&plugin_format);
+                let dest = install_dir.path.join(bundle_name);
+
+                operations.push(platform::types::InstallOperation {
+                    format: plugin_format.clone(),
+                    source: bundle_path,
+                    destination: dest.clone(),
+                });
+
+                let dest_string = dest.to_string_lossy().to_string();
+                match plugin_format {
+                    PluginFormat::Au => new_install_paths.au = Some(dest_string),
+                    PluginFormat::Vst3 => new_install_paths.vst3 = Some(dest_string),
+                }
             }
-
-            copy_dir_recursive(&bundle_path, &dest)
-                .map_err(|e| format!("Failed to copy AU bundle: {}", e))?;
-
-            new_install_paths.au = Some(dest.to_string_lossy().to_string());
-            log::info!("Installed AU bundle to: {}", dest.display());
-        }
-    }
-
-    // Search for .vst3 bundles in build directory
-    if let Ok(entries) = find_bundles(build_path, "vst3") {
-        for bundle_path in entries {
-            let bundle_name = bundle_path
-                .file_name()
-                .ok_or_else(|| "Invalid bundle name".to_string())?;
-            let dest = vst3_dest.join(bundle_name);
-
-            // Remove existing bundle if present
-            if dest.exists() {
-                std::fs::remove_dir_all(&dest)
-                    .map_err(|e| format!("Failed to remove existing VST3: {}", e))?;
-            }
-
-            copy_dir_recursive(&bundle_path, &dest)
-                .map_err(|e| format!("Failed to copy VST3 bundle: {}", e))?;
-
-            new_install_paths.vst3 = Some(dest.to_string_lossy().to_string());
-            log::info!("Installed VST3 bundle to: {}", dest.display());
         }
     }
 
     if new_install_paths.au.is_none() && new_install_paths.vst3.is_none() {
         return Err("No AU or VST3 bundles found in build directory".to_string());
     }
+
+    platform::install_plugin_bundles(&operations)?;
+    platform::post_install_refresh()?;
 
     // Update plugin state
     plugin.current_version = version_number;
@@ -206,22 +191,6 @@ fn find_bundles_recursive(
         }
         if path.is_dir() {
             find_bundles_recursive(&path, extension, results)?;
-        }
-    }
-    Ok(())
-}
-
-/// Recursively copy a directory
-fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), std::io::Error> {
-    std::fs::create_dir_all(dst)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let src_path = entry.path();
-        let dst_path = dst.join(entry.file_name());
-        if src_path.is_dir() {
-            copy_dir_recursive(&src_path, &dst_path)?;
-        } else {
-            std::fs::copy(&src_path, &dst_path)?;
         }
     }
     Ok(())

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -18,31 +18,48 @@ pub async fn refresh_model_catalog() -> Result<Vec<AgentProvider>, String> {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InstallPathsConfig {
-    pub au_path: String,
-    pub vst3_path: String,
+    pub platform: String,
+    pub supported_formats: Vec<String>,
+    pub au_path: Option<String>,
+    pub vst3_path: Option<String>,
     pub au_is_default: bool,
     pub vst3_is_default: bool,
 }
 
 #[command]
 pub async fn get_install_paths() -> Result<InstallPathsConfig, String> {
-    let au_default = platform::default_plugin_install_dir(&PluginFormat::Au);
-    let vst3_default = platform::default_plugin_install_dir(&PluginFormat::Vst3);
+    let supported_formats = platform::available_plugin_formats();
+    let supports_au = supported_formats.contains(&PluginFormat::Au);
+    let supports_vst3 = supported_formats.contains(&PluginFormat::Vst3);
 
-    let au_override = foundry_paths::install_path_override(&PluginFormat::Au);
-    let vst3_override = foundry_paths::install_path_override(&PluginFormat::Vst3);
+    let au_default = supports_au.then(|| platform::default_plugin_install_dir(&PluginFormat::Au));
+    let vst3_default =
+        supports_vst3.then(|| platform::default_plugin_install_dir(&PluginFormat::Vst3));
+
+    let au_override = supports_au
+        .then(|| foundry_paths::install_path_override(&PluginFormat::Au))
+        .flatten();
+    let vst3_override = supports_vst3
+        .then(|| foundry_paths::install_path_override(&PluginFormat::Vst3))
+        .flatten();
 
     Ok(InstallPathsConfig {
+        platform: current_platform().into(),
+        supported_formats: supported_formats
+            .iter()
+            .map(|format| match format {
+                PluginFormat::Au => "AU".to_string(),
+                PluginFormat::Vst3 => "VST3".to_string(),
+            })
+            .collect(),
         au_path: au_override
             .as_ref()
-            .unwrap_or(&au_default.path)
-            .to_string_lossy()
-            .to_string(),
+            .or(au_default.as_ref().map(|dir| &dir.path))
+            .map(|path| path.to_string_lossy().to_string()),
         vst3_path: vst3_override
             .as_ref()
-            .unwrap_or(&vst3_default.path)
-            .to_string_lossy()
-            .to_string(),
+            .or(vst3_default.as_ref().map(|dir| &dir.path))
+            .map(|path| path.to_string_lossy().to_string()),
         au_is_default: au_override.is_none(),
         vst3_is_default: vst3_override.is_none(),
     })
@@ -50,11 +67,7 @@ pub async fn get_install_paths() -> Result<InstallPathsConfig, String> {
 
 #[command]
 pub async fn set_install_path(format: String, path: String) -> Result<InstallPathsConfig, String> {
-    let plugin_format = match format.to_uppercase().as_str() {
-        "AU" => PluginFormat::Au,
-        "VST3" => PluginFormat::Vst3,
-        _ => return Err(format!("Unknown format: {}", format)),
-    };
+    let plugin_format = parse_supported_format(&format)?;
 
     foundry_paths::set_install_path_override(&plugin_format, &path)?;
     get_install_paths().await
@@ -62,12 +75,41 @@ pub async fn set_install_path(format: String, path: String) -> Result<InstallPat
 
 #[command]
 pub async fn reset_install_path(format: String) -> Result<InstallPathsConfig, String> {
+    let plugin_format = parse_supported_format(&format)?;
+
+    foundry_paths::clear_install_path_override(&plugin_format)?;
+    get_install_paths().await
+}
+
+fn parse_supported_format(format: &str) -> Result<PluginFormat, String> {
     let plugin_format = match format.to_uppercase().as_str() {
         "AU" => PluginFormat::Au,
         "VST3" => PluginFormat::Vst3,
         _ => return Err(format!("Unknown format: {}", format)),
     };
 
-    foundry_paths::clear_install_path_override(&plugin_format)?;
-    get_install_paths().await
+    if !platform::available_plugin_formats().contains(&plugin_format) {
+        return Err(format!(
+            "{} is not supported on {}",
+            format.to_uppercase(),
+            current_platform()
+        ));
+    }
+
+    Ok(plugin_format)
+}
+
+fn current_platform() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "macos"
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "windows"
+    }
+    #[cfg(target_os = "linux")]
+    {
+        "linux"
+    }
 }

--- a/src-tauri/src/platform/linux.rs
+++ b/src-tauri/src/platform/linux.rs
@@ -163,6 +163,11 @@ pub fn required_dependencies() -> Vec<DependencySpec> {
             check_command: "claude",
             check_args: &["--version"],
         },
+        DependencySpec {
+            name: "Codex CLI",
+            check_command: "codex",
+            check_args: &["--version"],
+        },
     ]
 }
 

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -64,8 +64,9 @@ pub fn create_command(cmd: &str) -> Command {
 pub fn cmake_configure_args() -> Vec<String> {
     vec![
         "-G".into(),
-        "Ninja".into(),
-        "-DCMAKE_BUILD_TYPE=Debug".into(),
+        "Visual Studio 17 2022".into(),
+        "-A".into(),
+        "x64".into(),
     ]
 }
 
@@ -196,7 +197,7 @@ pub fn required_dependencies() -> Vec<DependencySpec> {
     vec![
         DependencySpec {
             name: "C++ Build Tools",
-            check_command: "cl",
+            check_command: "__vs_build_tools__",
             check_args: &[],
         },
         DependencySpec {
@@ -205,13 +206,13 @@ pub fn required_dependencies() -> Vec<DependencySpec> {
             check_args: &["--version"],
         },
         DependencySpec {
-            name: "Ninja",
-            check_command: "ninja",
+            name: "Claude Code CLI",
+            check_command: "claude",
             check_args: &["--version"],
         },
         DependencySpec {
-            name: "Claude Code CLI",
-            check_command: "claude",
+            name: "Codex CLI",
+            check_command: "codex",
             check_args: &["--version"],
         },
     ]
@@ -219,6 +220,10 @@ pub fn required_dependencies() -> Vec<DependencySpec> {
 
 /// Check a dependency by resolving and running its command.
 pub fn check_dependency(spec: &DependencySpec) -> Option<String> {
+    if spec.check_command == "__vs_build_tools__" {
+        return resolve_visual_studio_installation();
+    }
+
     let resolved = resolve_command(spec.check_command);
     Command::new(&resolved)
         .args(spec.check_args)
@@ -254,6 +259,41 @@ pub fn show_in_file_manager(path: &str) -> Result<(), String> {
 
 pub fn invalidate_shell_cache() {
     // No-op on Windows — shell env is not cached with OnceLock on this platform.
+}
+
+fn resolve_visual_studio_installation() -> Option<String> {
+    let program_files_x86 = std::env::var("ProgramFiles(x86)")
+        .or_else(|_| std::env::var("ProgramFiles"))
+        .ok()?;
+    let vswhere = PathBuf::from(program_files_x86)
+        .join("Microsoft Visual Studio")
+        .join("Installer")
+        .join("vswhere.exe");
+
+    if !vswhere.is_file() {
+        return None;
+    }
+
+    let output = Command::new(vswhere)
+        .args([
+            "-latest",
+            "-products",
+            "*",
+            "-requires",
+            "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+            "-property",
+            "installationPath",
+        ])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let installation_path = stdout.trim();
+    (!installation_path.is_empty()).then(|| installation_path.to_string())
 }
 
 fn copy_dir_all(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {

--- a/src-tauri/src/services/auth_service.rs
+++ b/src-tauri/src/services/auth_service.rs
@@ -65,10 +65,7 @@ impl SupabaseAuth {
     }
 
     fn session_file_path() -> PathBuf {
-        let mut path = dirs::home_dir().unwrap_or_default();
-        path.push("Library/Application Support/Foundry");
-        path.push("auth_session.json");
-        path
+        crate::services::foundry_paths::application_support_dir().join("auth_session.json")
     }
 
     fn persist_session(session: &AuthSession) -> Result<(), String> {
@@ -387,10 +384,7 @@ impl SupabaseAuth {
             None => return Err("Not authenticated".to_string()),
         };
 
-        let url = format!(
-            "{}/rest/v1/profiles?id=eq.{}",
-            *SUPABASE_URL, user_id
-        );
+        let url = format!("{}/rest/v1/profiles?id=eq.{}", *SUPABASE_URL, user_id);
 
         let body = serde_json::json!({
             "card_variant": variant,
@@ -417,7 +411,11 @@ impl SupabaseAuth {
     }
 
     /// Batch assign a card variant to multiple users by email.
-    pub async fn assign_card_variant_batch(&self, emails: Vec<String>, variant: &str) -> Result<u32, String> {
+    pub async fn assign_card_variant_batch(
+        &self,
+        emails: Vec<String>,
+        variant: &str,
+    ) -> Result<u32, String> {
         let session = self.session.lock().unwrap().clone();
         let session = match session {
             Some(s) => s,
@@ -444,15 +442,11 @@ impl SupabaseAuth {
                 .map_err(|e| format!("Request failed: {}", e))?;
 
             let text = resp.text().await.unwrap_or_default();
-            let profiles: Vec<serde_json::Value> =
-                serde_json::from_str(&text).unwrap_or_default();
+            let profiles: Vec<serde_json::Value> = serde_json::from_str(&text).unwrap_or_default();
 
             if let Some(profile) = profiles.first() {
                 if let Some(id) = profile.get("id").and_then(|v| v.as_str()) {
-                    let patch_url = format!(
-                        "{}/rest/v1/profiles?id=eq.{}",
-                        *SUPABASE_URL, id
-                    );
+                    let patch_url = format!("{}/rest/v1/profiles?id=eq.{}", *SUPABASE_URL, id);
 
                     let body = serde_json::json!({
                         "card_variant": variant,

--- a/src-tauri/src/services/build_environment.rs
+++ b/src-tauri/src/services/build_environment.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 
 use chrono::Utc;
@@ -266,6 +267,16 @@ fn collect_dependency_issues() -> Vec<BuildEnvironmentIssue> {
                     "CMake is required before Foundry can configure JUCE projects.",
                     Some("Install CMake"),
                 ),
+                "C++ Build Tools" => (
+                    "cpp_build_tools_missing",
+                    "Install Visual Studio 2022 Build Tools with the Desktop C++ workload.",
+                    Some("Install Build Tools"),
+                ),
+                "Ninja" => (
+                    "ninja_missing",
+                    "Ninja is required before Foundry can build JUCE projects.",
+                    Some("Install Ninja"),
+                ),
                 "Claude Code CLI" => (
                     "claude_cli_missing",
                     "Claude Code CLI is required before Foundry can generate code.",
@@ -294,82 +305,95 @@ fn collect_dependency_issues() -> Vec<BuildEnvironmentIssue> {
 }
 
 async fn download_and_install_managed_juce(app: Option<&AppHandle>) -> Result<PathBuf, String> {
-    #[cfg(not(target_os = "macos"))]
-    {
-        let _ = app;
-        return Err("Automatic JUCE installation is currently implemented only on macOS.".into());
+    let managed_root = foundry_paths::managed_juce_root_dir();
+    let final_path = foundry_paths::managed_juce_dir(&foundry_paths::DEFAULT_MANAGED_JUCE_VERSION);
+    let temp_root = foundry_paths::application_support_dir().join("tmp");
+    let extract_root = temp_root.join(format!("juce-extract-{}", uuid::Uuid::new_v4().simple()));
+    let archive_path = temp_root.join(format!(
+        "juce-{}-{}.zip",
+        foundry_paths::DEFAULT_MANAGED_JUCE_VERSION,
+        uuid::Uuid::new_v4().simple()
+    ));
+
+    fs::create_dir_all(&managed_root).map_err(|error| error.to_string())?;
+    fs::create_dir_all(&temp_root).map_err(|error| error.to_string())?;
+
+    let cleanup = |archive: &Path, extract: &Path| {
+        let _ = fs::remove_file(archive);
+        let _ = fs::remove_dir_all(extract);
+    };
+
+    let response = reqwest::get(JUCE_DOWNLOAD_URL)
+        .await
+        .map_err(|error| error.to_string())?
+        .error_for_status()
+        .map_err(|error| error.to_string())?;
+    let body = response.bytes().await.map_err(|error| error.to_string())?;
+    tokio::fs::write(&archive_path, body)
+        .await
+        .map_err(|error| error.to_string())?;
+
+    if let Some(app_handle) = app {
+        emit_log(app_handle, "Extracting JUCE archive...", None);
     }
 
-    #[cfg(target_os = "macos")]
-    {
-        let managed_root = foundry_paths::managed_juce_root_dir();
-        let final_path =
-            foundry_paths::managed_juce_dir(&foundry_paths::DEFAULT_MANAGED_JUCE_VERSION);
-        let temp_root = foundry_paths::application_support_dir().join("tmp");
-        let extract_root =
-            temp_root.join(format!("juce-extract-{}", uuid::Uuid::new_v4().simple()));
-        let archive_path = temp_root.join(format!(
-            "juce-{}-{}.zip",
-            foundry_paths::DEFAULT_MANAGED_JUCE_VERSION,
-            uuid::Uuid::new_v4().simple()
-        ));
-
-        fs::create_dir_all(&managed_root).map_err(|error| error.to_string())?;
-        fs::create_dir_all(&temp_root).map_err(|error| error.to_string())?;
-
-        let cleanup = |archive: &Path, extract: &Path| {
-            let _ = fs::remove_file(archive);
-            let _ = fs::remove_dir_all(extract);
-        };
-
-        let response = reqwest::get(JUCE_DOWNLOAD_URL)
-            .await
-            .map_err(|error| error.to_string())?
-            .error_for_status()
-            .map_err(|error| error.to_string())?;
-        let body = response.bytes().await.map_err(|error| error.to_string())?;
-        tokio::fs::write(&archive_path, body)
-            .await
-            .map_err(|error| error.to_string())?;
-
-        if let Some(app_handle) = app {
-            emit_log(app_handle, "Extracting JUCE archive...", None);
-        }
-
-        fs::create_dir_all(&extract_root).map_err(|error| error.to_string())?;
-        let extraction = platform::create_command("ditto")
-            .args(["-x", "-k"])
-            .arg(&archive_path)
-            .arg(&extract_root)
-            .output()
-            .map_err(|error| error.to_string())?;
-
-        if !extraction.status.success() {
-            cleanup(&archive_path, &extract_root);
-            let stderr = String::from_utf8_lossy(&extraction.stderr);
-            return Err(format!("Failed to extract JUCE archive: {}", stderr.trim()));
-        }
-
-        let extracted_path = find_extracted_juce_root(&extract_root)?.ok_or_else(|| {
-            "The JUCE archive was extracted, but the JUCE root directory could not be found."
-                .to_string()
-        })?;
-
-        if let Some(app_handle) = app {
-            emit_log(app_handle, "Validating JUCE installation...", None);
-        }
-
-        validate_juce_directory(&extracted_path)?;
-
-        if final_path.exists() {
-            fs::remove_dir_all(&final_path).map_err(|error| error.to_string())?;
-        }
-
-        fs::rename(&extracted_path, &final_path).map_err(|error| error.to_string())?;
+    fs::create_dir_all(&extract_root).map_err(|error| error.to_string())?;
+    extract_zip_archive(&archive_path, &extract_root).inspect_err(|_| {
         cleanup(&archive_path, &extract_root);
+    })?;
 
-        Ok(final_path)
+    let extracted_path = find_extracted_juce_root(&extract_root)?.ok_or_else(|| {
+        "The JUCE archive was extracted, but the JUCE root directory could not be found."
+            .to_string()
+    })?;
+
+    if let Some(app_handle) = app {
+        emit_log(app_handle, "Validating JUCE installation...", None);
     }
+
+    validate_juce_directory(&extracted_path)?;
+
+    if final_path.exists() {
+        fs::remove_dir_all(&final_path).map_err(|error| error.to_string())?;
+    }
+
+    fs::rename(&extracted_path, &final_path).map_err(|error| error.to_string())?;
+    cleanup(&archive_path, &extract_root);
+
+    Ok(final_path)
+}
+
+fn extract_zip_archive(archive_path: &Path, extract_root: &Path) -> Result<(), String> {
+    let file = fs::File::open(archive_path).map_err(|error| error.to_string())?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|error| error.to_string())?;
+
+    for index in 0..archive.len() {
+        let mut entry = archive.by_index(index).map_err(|error| error.to_string())?;
+        let Some(relative_path) = entry.enclosed_name().map(|path| path.to_path_buf()) else {
+            continue;
+        };
+        let output_path = extract_root.join(relative_path);
+
+        if entry.is_dir() {
+            fs::create_dir_all(&output_path).map_err(|error| error.to_string())?;
+            continue;
+        }
+
+        if let Some(parent) = output_path.parent() {
+            fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+        }
+
+        let mut output = fs::File::create(&output_path).map_err(|error| error.to_string())?;
+        io::copy(&mut entry, &mut output).map_err(|error| error.to_string())?;
+
+        #[cfg(unix)]
+        if let Some(mode) = entry.unix_mode() {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(&output_path, fs::Permissions::from_mode(mode));
+        }
+    }
+
+    Ok(())
 }
 
 fn find_extracted_juce_root(extract_root: &Path) -> Result<Option<PathBuf>, String> {

--- a/src-tauri/src/services/build_runner.rs
+++ b/src-tauri/src/services/build_runner.rs
@@ -172,6 +172,9 @@ fn classify_build_failure(raw: &str, configure_phase: bool) -> BuildFailureStage
         "no cxx compiler could be found",
         "cmake error at cmakelists.txt",
         "unable to find utility",
+        "could not find any instance of visual studio",
+        "could not find a version of visual studio",
+        "desktop c++ workload",
     ];
 
     if environment_markers

--- a/src-tauri/src/services/generation_pipeline.rs
+++ b/src-tauri/src/services/generation_pipeline.rs
@@ -2253,10 +2253,22 @@ mod tests {
 }
 
 fn resolve_formats(format: &str) -> Vec<PluginFormat> {
-    match format.to_uppercase().as_str() {
+    let requested = match format.to_uppercase().as_str() {
         "AU" => vec![PluginFormat::Au],
         "VST3" => vec![PluginFormat::Vst3],
         _ => vec![PluginFormat::Au, PluginFormat::Vst3],
+    };
+
+    let supported = crate::platform::available_plugin_formats();
+    let resolved: Vec<PluginFormat> = requested
+        .into_iter()
+        .filter(|plugin_format| supported.contains(plugin_format))
+        .collect();
+
+    if resolved.is_empty() {
+        supported
+    } else {
+        resolved
     }
 }
 

--- a/src-tauri/src/services/onboarding.rs
+++ b/src-tauri/src/services/onboarding.rs
@@ -99,27 +99,38 @@ pub async fn complete_onboarding(auth: &SupabaseAuth) -> Result<OnboardingState,
 
 /// Install Xcode Command Line Tools. Launches the macOS installer GUI.
 pub fn install_xcode_clt() -> DependencyInstallResult {
-    let output = Command::new("xcode-select").args(["--install"]).output();
+    #[cfg(not(target_os = "macos"))]
+    {
+        return DependencyInstallResult {
+            success: false,
+            message: "Xcode Command Line Tools are only available on macOS.".into(),
+        };
+    }
 
-    match output {
-        Ok(o) => {
-            let stderr = String::from_utf8_lossy(&o.stderr);
-            if stderr.contains("already installed") {
-                DependencyInstallResult {
-                    success: true,
-                    message: "Xcode Command Line Tools are already installed.".into(),
-                }
-            } else {
-                DependencyInstallResult {
+    #[cfg(target_os = "macos")]
+    {
+        let output = Command::new("xcode-select").args(["--install"]).output();
+
+        match output {
+            Ok(o) => {
+                let stderr = String::from_utf8_lossy(&o.stderr);
+                if stderr.contains("already installed") {
+                    DependencyInstallResult {
+                        success: true,
+                        message: "Xcode Command Line Tools are already installed.".into(),
+                    }
+                } else {
+                    DependencyInstallResult {
                     success: true,
                     message: "Xcode Command Line Tools installer launched. Please complete the installation in the popup window.".into(),
                 }
+                }
             }
+            Err(e) => DependencyInstallResult {
+                success: false,
+                message: format!("Failed to launch installer: {}", e),
+            },
         }
-        Err(e) => DependencyInstallResult {
-            success: false,
-            message: format!("Failed to launch installer: {}", e),
-        },
     }
 }
 
@@ -141,6 +152,14 @@ fn resolve_npm_path() -> Option<String> {
     if resolved != "npm" {
         return Some(resolved);
     }
+    #[cfg(target_os = "windows")]
+    {
+        let resolved = platform::resolve_command("npm.cmd");
+        if resolved != "npm.cmd" {
+            return Some(resolved);
+        }
+    }
+    #[cfg(target_os = "macos")]
     for path in &["/opt/homebrew/bin/npm", "/usr/local/bin/npm"] {
         if std::path::Path::new(path).is_file() {
             return Some(path.to_string());
@@ -149,8 +168,96 @@ fn resolve_npm_path() -> Option<String> {
     None
 }
 
+#[cfg(target_os = "windows")]
+fn resolve_winget_path() -> Option<String> {
+    let resolved = platform::resolve_command("winget");
+    if resolved != "winget" {
+        return Some(resolved);
+    }
+
+    let local_app_data = std::env::var("LOCALAPPDATA").ok()?;
+    let fallback = std::path::Path::new(&local_app_data)
+        .join("Microsoft")
+        .join("WindowsApps")
+        .join("winget.exe");
+
+    fallback
+        .is_file()
+        .then(|| fallback.to_string_lossy().to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn run_winget_install(
+    package_id: &str,
+    display_name: &str,
+    extra_args: &[&str],
+) -> DependencyInstallResult {
+    let winget = match resolve_winget_path() {
+        Some(path) => path,
+        None => {
+            return DependencyInstallResult {
+                success: false,
+                message: format!(
+                    "winget is not available. Install {} manually, then click Re-check.",
+                    display_name
+                ),
+            };
+        }
+    };
+
+    let mut args = vec![
+        "install",
+        "--id",
+        package_id,
+        "-e",
+        "--accept-package-agreements",
+        "--accept-source-agreements",
+        "--silent",
+    ];
+    args.extend_from_slice(extra_args);
+
+    let result = Command::new(&winget).args(&args).output();
+
+    match result {
+        Ok(output) if output.status.success() => DependencyInstallResult {
+            success: true,
+            message: format!("{} installed successfully.", display_name),
+        },
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let combined = format!("{}\n{}", stdout, stderr);
+            if combined.contains("No available upgrade found")
+                || combined.contains("No installed package found matching input criteria")
+                || combined.contains("already installed")
+            {
+                DependencyInstallResult {
+                    success: true,
+                    message: format!("{} is already installed.", display_name),
+                }
+            } else {
+                DependencyInstallResult {
+                    success: false,
+                    message: format!("Failed to install {}: {}", display_name, combined.trim()),
+                }
+            }
+        }
+        Err(error) => DependencyInstallResult {
+            success: false,
+            message: format!("Failed to run winget: {}", error),
+        },
+    }
+}
+
 fn install_homebrew() -> Result<(), String> {
-    let result = Command::new("/bin/bash")
+    #[cfg(not(target_os = "macos"))]
+    {
+        return Err("Homebrew installation is only supported on macOS.".into());
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let result = Command::new("/bin/bash")
         .args([
             "-c",
             "NONINTERACTIVE=1 /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
@@ -158,11 +265,12 @@ fn install_homebrew() -> Result<(), String> {
         .output()
         .map_err(|e| format!("Failed to run Homebrew installer: {}", e))?;
 
-    if !result.status.success() {
-        let stderr = String::from_utf8_lossy(&result.stderr);
-        return Err(format!("Homebrew installation failed: {}", stderr.trim()));
+        if !result.status.success() {
+            let stderr = String::from_utf8_lossy(&result.stderr);
+            return Err(format!("Homebrew installation failed: {}", stderr.trim()));
+        }
+        Ok(())
     }
-    Ok(())
 }
 
 /// Install CMake via Homebrew (installs Homebrew first if needed).
@@ -173,6 +281,11 @@ pub fn install_cmake() -> DependencyInstallResult {
             success: true,
             message: "CMake is already installed.".into(),
         };
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        return run_winget_install("Kitware.CMake", "CMake", &[]);
     }
 
     let brew = match resolve_brew_path() {
@@ -225,9 +338,45 @@ pub fn install_cmake() -> DependencyInstallResult {
     }
 }
 
+/// Install Visual Studio Build Tools on Windows.
+pub fn install_cpp_build_tools() -> DependencyInstallResult {
+    #[cfg(not(target_os = "windows"))]
+    {
+        return DependencyInstallResult {
+            success: false,
+            message: "C++ Build Tools installation is only available on Windows.".into(),
+        };
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        run_winget_install(
+            "Microsoft.VisualStudio.2022.BuildTools",
+            "Visual Studio Build Tools",
+            &[
+                "--override",
+                "--wait --passive --norestart --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended",
+            ],
+        )
+    }
+}
+
 fn ensure_npm() -> Result<String, String> {
     if let Some(npm) = resolve_npm_path() {
         return Ok(npm);
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let install_result = run_winget_install("OpenJS.NodeJS.LTS", "Node.js LTS", &[]);
+        if !install_result.success {
+            return Err(install_result.message);
+        }
+
+        return resolve_npm_path().ok_or_else(|| {
+            "Node.js installed but npm could not be found on PATH. Restart Foundry and try again."
+                .to_string()
+        });
     }
 
     let brew = resolve_brew_path().ok_or_else(|| {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,13 +19,7 @@
         "minHeight": 620,
         "resizable": true,
         "fullscreen": false,
-        "decorations": true,
-        "titleBarStyle": "Overlay",
-        "hiddenTitle": true,
-        "trafficLightPosition": {
-          "x": 13,
-          "y": 16
-        }
+        "decorations": true
       }
     ],
     "security": {
@@ -34,19 +28,11 @@
   },
   "bundle": {
     "active": true,
-    "targets": [
-      "dmg",
-      "app"
-    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
       "icons/128x128@2x.png",
-      "icons/icon.icns",
       "icons/icon.ico"
-    ],
-    "macOS": {
-      "minimumSystemVersion": "13.0"
-    }
+    ]
   }
 }

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,26 @@
+{
+  "app": {
+    "windows": [
+      {
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "trafficLightPosition": {
+          "x": 13,
+          "y": 16
+        }
+      }
+    ]
+  },
+  "bundle": {
+    "targets": [
+      "dmg",
+      "app"
+    ],
+    "icon": [
+      "icons/icon.icns"
+    ],
+    "macOS": {
+      "minimumSystemVersion": "13.0"
+    }
+  }
+}

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,8 @@
+{
+  "bundle": {
+    "targets": [
+      "nsis",
+      "msi"
+    ]
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -182,10 +182,14 @@ export default function App() {
   const initTheme = useSettingsStore((s) => s.initTheme)
   const loadBuildEnvironment = useSettingsStore((s) => s.loadBuildEnvironment)
   const loadCatalog = useSettingsStore((s) => s.loadCatalog)
+  const loadInstallPaths = useSettingsStore((s) => s.loadInstallPaths)
+  const installPaths = useSettingsStore((s) => s.installPaths)
+  const titlebarInset = installPaths?.platform === "macos" ? 52 : 0
 
   useEffect(() => { initTheme() }, [initTheme])
   useEffect(() => { loadBuildEnvironment() }, [loadBuildEnvironment])
   useEffect(() => { loadCatalog() }, [loadCatalog])
+  useEffect(() => { loadInstallPaths() }, [loadInstallPaths])
   useEffect(() => { checkSession() }, [checkSession])
 
   useEffect(() => {
@@ -212,9 +216,10 @@ export default function App() {
       <div className="flex flex-col h-full">
         <div
           data-tauri-drag-region
-          className="h-[52px] shrink-0 select-none"
+          className="shrink-0 select-none"
+          style={{ height: titlebarInset }}
         >
-          <div className="w-[78px] shrink-0" data-tauri-drag-region />
+          {titlebarInset > 0 && <div className="w-[78px] h-full shrink-0" data-tauri-drag-region />}
         </div>
         <div className="flex-1 overflow-hidden">
           <Onboarding />
@@ -231,9 +236,10 @@ export default function App() {
         {/* Drag region for main content area */}
         <div
           data-tauri-drag-region
-          className="h-[52px] shrink-0 select-none"
+          className="shrink-0 select-none"
+          style={{ height: titlebarInset }}
         />
-        <div className="h-[calc(100%-52px)] overflow-hidden">
+        <div className="flex-1 overflow-hidden">
           <MainContent />
         </div>
       </SidebarInset>

--- a/src/components/app/plugin-detail-view.tsx
+++ b/src/components/app/plugin-detail-view.tsx
@@ -24,7 +24,7 @@ export function PluginDetailView({ plugin }: Props) {
   const setMainView = useAppStore((s) => s.setMainView)
   const deletePlugin = useAppStore((s) => s.deletePlugin)
   const loadPlugins = useAppStore((s) => s.loadPlugins)
-  const openFinder = () => {
+  const openFolder = () => {
     const path = plugin.installPaths.vst3 || plugin.installPaths.au
     if (path) showInFinder(path)
   }
@@ -73,8 +73,8 @@ export function PluginDetailView({ plugin }: Props) {
                 }
               />
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={openFinder}>
-                  Show in Finder
+                <DropdownMenuItem onClick={openFolder}>
+                  Show in Folder
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={handleDelete} className="text-destructive">
                   Delete

--- a/src/components/app/sidebar-plugin-row.tsx
+++ b/src/components/app/sidebar-plugin-row.tsx
@@ -81,7 +81,7 @@ export function SidebarPluginRow({
       </ContextMenuTrigger>
       <ContextMenuContent>
         <ContextMenuItem onClick={onShowInFinder}>
-          Show in Finder
+          Show in Folder
         </ContextMenuItem>
         <ContextMenuItem onClick={onRename}>
           Rename

--- a/src/components/app/sidebar.tsx
+++ b/src/components/app/sidebar.tsx
@@ -204,7 +204,7 @@ export function AppSidebar() {
         <DialogContent showCloseButton={false}>
           <DialogHeader>
             <DialogTitle>Delete Plugin?</DialogTitle>
-            <DialogDescription>This will uninstall the AU/VST3 files from your system. This cannot be undone.</DialogDescription>
+            <DialogDescription>This removes the plugin from Foundry. Installed files on disk are not deleted automatically.</DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" onClick={() => setPluginToDelete(null)}>Cancel</Button>

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -8,6 +8,7 @@ import type {
   AgentProvider,
   GenerationTelemetry,
   UserProfile,
+  RawUserProfile,
   OnboardingState,
   DependencyInstallResult,
 } from "@/lib/types"
@@ -20,7 +21,7 @@ export const signUp = (email: string, password: string) =>
 export const signOut = () => invoke<void>("sign_out");
 export const checkSession = () => invoke<string | null>("check_session");
 export const getProfile = (userId: string) =>
-  invoke<UserProfile | null>("get_profile", { userId });
+  invoke<RawUserProfile | null>("get_profile", { userId });
 export const updateCardVariant = (userId: string, variant: string) =>
   invoke<void>("update_card_variant", { userId, variant });
 export const assignCardVariantBatch = (emails: string[], variant: string) =>
@@ -56,8 +57,10 @@ export const getModelCatalog = () => invoke<AgentProvider[]>("get_model_catalog"
 export const refreshModelCatalog = () => invoke<AgentProvider[]>("refresh_model_catalog");
 
 export interface InstallPathsConfig {
-  auPath: string;
-  vst3Path: string;
+  platform: "macos" | "windows" | "linux";
+  supportedFormats: Array<"AU" | "VST3">;
+  auPath?: string;
+  vst3Path?: string;
   auIsDefault: boolean;
   vst3IsDefault: boolean;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -105,6 +105,15 @@ export interface UserProfile {
   cardVariant?: CardVariant;
 }
 
+export interface RawUserProfile extends Partial<UserProfile> {
+  display_name?: string;
+  avatar_url?: string;
+  plugins_generated?: number;
+  created_at?: string;
+  onboarding_completed_at?: string;
+  card_variant?: CardVariant;
+}
+
 export interface DependencyStatus {
   name: string;
   installed: boolean;

--- a/src/pages/Error.tsx
+++ b/src/pages/Error.tsx
@@ -15,6 +15,11 @@ function classifyFailure(message: string) {
     lower.includes("juce_add_plugin") ||
     lower.includes("add_subdirectory given source") ||
     lower.includes("xcode command line tools") ||
+    lower.includes("c++ build tools") ||
+    lower.includes("visual studio 2022 build tools") ||
+    lower.includes("visual studio build tools") ||
+    lower.includes("desktop c++ workload") ||
+    lower.includes("ninja is required") ||
     lower.includes("cmake is required") ||
     lower.includes("claude code cli")
   ) {
@@ -30,7 +35,7 @@ function classifyFailure(message: string) {
   }
 
   if (lower.includes("no plugin bundles found") || lower.includes("bundle")) {
-    return { title: "Build Output Invalid", subtitle: "The build completed without producing a usable AU or VST3 bundle.", kind: "build" }
+    return { title: "Build Output Invalid", subtitle: "The build completed without producing a usable plugin bundle.", kind: "build" }
   }
 
   if (lower.includes("compile") || lower.includes("cmake") || lower.includes("error:") || lower.includes("build failed")) {

--- a/src/pages/Prompt.tsx
+++ b/src/pages/Prompt.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { AgentIcon } from "@/components/app/agent-icon"
 import { ArrowUpRight } from "lucide-react"
+import type { FormatOption } from "@/lib/types"
 
 const suggestions = [
   {
@@ -74,6 +75,7 @@ export default function Prompt() {
   const setMainView = useAppStore((s) => s.setMainView)
   const startGeneration = useBuildStore((s) => s.startGeneration)
   const modelCatalog = useSettingsStore((s) => s.modelCatalog)
+  const installPaths = useSettingsStore((s) => s.installPaths)
   const [prompt, setPrompt] = useState("")
   const [selectedAgent, setSelectedAgent] = useState("Claude Code")
   const [selectedModel, setSelectedModel] = useState("sonnet")
@@ -81,10 +83,14 @@ export default function Prompt() {
 
   const generate = async () => {
     if (isEmpty) return
+    const format: FormatOption =
+      installPaths?.supportedFormats.length === 1
+        ? installPaths.supportedFormats[0]
+        : "Both"
     setMainView({ kind: "generation" })
     void startGeneration({
       prompt: prompt.trim(),
-      format: "Both",
+      format,
       channelLayout: "Stereo",
       presetCount: 5,
       agent: selectedAgent,
@@ -98,6 +104,11 @@ export default function Prompt() {
         {/* Hero */}
         <div className="flex flex-col items-center gap-2.5 mb-8">
           <span className="text-[14px] text-muted-foreground">Describe your plugin, Foundry builds it.</span>
+          {installPaths?.supportedFormats.length === 1 && (
+            <span className="text-[11px] uppercase tracking-[1px] text-muted-foreground/60">
+              {installPaths.supportedFormats[0]} only on this platform
+            </span>
+          )}
         </div>
 
         {/* Prompt input */}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -3,7 +3,7 @@ import { getVersion } from "@tauri-apps/api/app"
 import { open } from "@tauri-apps/plugin-dialog"
 import { useAppStore } from "@/stores/app-store"
 import { useSettingsStore } from "@/stores/settings-store"
-import { checkDependencies, showInFinder } from "@/lib/commands"
+import { checkDependencies } from "@/lib/commands"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Label } from "@/components/ui/label"
@@ -46,6 +46,8 @@ export default function Settings() {
 function GeneralTab() {
   const { appearance, setAppearance, installPaths, loadInstallPaths, resetInstallPath } = useSettingsStore()
   const [appVersion, setAppVersion] = useState<string>("")
+  const supportsAu = installPaths?.supportedFormats.includes("AU") ?? false
+  const supportsVst3 = installPaths?.supportedFormats.includes("VST3") ?? false
 
   useEffect(() => { loadInstallPaths() }, [loadInstallPaths])
   useEffect(() => { getVersion().then(setAppVersion) }, [])
@@ -81,43 +83,47 @@ function GeneralTab() {
         </p>
 
         <div className="flex flex-col gap-2">
-          <div className="flex flex-col gap-1.5">
-            <Label className="text-xs text-muted-foreground">AU Components</Label>
-            <div className="flex items-center gap-2">
-              <Input
-                readOnly
-                value={installPaths?.auPath ?? "/Library/Audio/Plug-Ins/Components"}
-                className="flex-1 cursor-default"
-              />
-              <Button variant="outline" size="sm" onClick={() => chooseFolder("AU")}>
-                <FolderOpen className="size-3.5" />
-              </Button>
-              {installPaths && !installPaths.auIsDefault && (
-                <Button variant="ghost" size="sm" onClick={() => resetInstallPath("AU")}>
-                  <RotateCcw className="size-3.5" />
+          {supportsAu && (
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-xs text-muted-foreground">AU Components</Label>
+              <div className="flex items-center gap-2">
+                <Input
+                  readOnly
+                  value={installPaths?.auPath ?? ""}
+                  className="flex-1 cursor-default"
+                />
+                <Button variant="outline" size="sm" onClick={() => chooseFolder("AU")}>
+                  <FolderOpen className="size-3.5" />
                 </Button>
-              )}
+                {installPaths && !installPaths.auIsDefault && (
+                  <Button variant="ghost" size="sm" onClick={() => resetInstallPath("AU")}>
+                    <RotateCcw className="size-3.5" />
+                  </Button>
+                )}
+              </div>
             </div>
-          </div>
+          )}
 
-          <div className="flex flex-col gap-1.5">
-            <Label className="text-xs text-muted-foreground">VST3 Plugins</Label>
-            <div className="flex items-center gap-2">
-              <Input
-                readOnly
-                value={installPaths?.vst3Path ?? "/Library/Audio/Plug-Ins/VST3"}
-                className="flex-1 cursor-default"
-              />
-              <Button variant="outline" size="sm" onClick={() => chooseFolder("VST3")}>
-                <FolderOpen className="size-3.5" />
-              </Button>
-              {installPaths && !installPaths.vst3IsDefault && (
-                <Button variant="ghost" size="sm" onClick={() => resetInstallPath("VST3")}>
-                  <RotateCcw className="size-3.5" />
+          {supportsVst3 && (
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-xs text-muted-foreground">VST3 Plugins</Label>
+              <div className="flex items-center gap-2">
+                <Input
+                  readOnly
+                  value={installPaths?.vst3Path ?? ""}
+                  className="flex-1 cursor-default"
+                />
+                <Button variant="outline" size="sm" onClick={() => chooseFolder("VST3")}>
+                  <FolderOpen className="size-3.5" />
                 </Button>
-              )}
+                {installPaths && !installPaths.vst3IsDefault && (
+                  <Button variant="ghost" size="sm" onClick={() => resetInstallPath("VST3")}>
+                    <RotateCcw className="size-3.5" />
+                  </Button>
+                )}
+              </div>
             </div>
-          </div>
+          )}
         </div>
       </div>
 
@@ -175,13 +181,112 @@ function ModelsTab() {
 
 function DependenciesTab() {
   const [deps, setDeps] = useState<DependencyStatus[]>([])
+  const buildEnvironment = useSettingsStore((s) => s.buildEnvironment)
+  const loadBuildEnvironment = useSettingsStore((s) => s.loadBuildEnvironment)
+  const installManagedJuce = useSettingsStore((s) => s.installManagedJuce)
+  const setJuceOverride = useSettingsStore((s) => s.setJuceOverride)
+  const clearJuceOverride = useSettingsStore((s) => s.clearJuceOverride)
+  const isPreparingEnvironment = useSettingsStore((s) => s.isPreparingEnvironment)
+  const isLoadingBuildEnvironment = useSettingsStore((s) => s.isLoadingBuildEnvironment)
+
+  const optionalDeps = new Set(["Codex CLI"])
+
+  const refreshDeps = useCallback(async () => {
+    try {
+      const next = await checkDependencies()
+      setDeps(next)
+    } catch {
+      setDeps([])
+    }
+  }, [])
 
   useEffect(() => {
-    checkDependencies().then(setDeps).catch(() => setDeps([]))
-  }, [])
+    void refreshDeps()
+    void loadBuildEnvironment()
+  }, [refreshDeps, loadBuildEnvironment])
+
+  const chooseJuceFolder = useCallback(async () => {
+    const selection = await open({ directory: true, multiple: false })
+    if (typeof selection !== "string") return
+    await setJuceOverride(selection)
+    await refreshDeps()
+  }, [refreshDeps, setJuceOverride])
+
+  const installManagedCopy = useCallback(async () => {
+    await installManagedJuce()
+    await refreshDeps()
+  }, [installManagedJuce, refreshDeps])
+
+  const restoreManagedCopy = useCallback(async () => {
+    await clearJuceOverride()
+    await refreshDeps()
+  }, [clearJuceOverride, refreshDeps])
+
+  const recheckEnvironment = useCallback(async () => {
+    await Promise.all([refreshDeps(), loadBuildEnvironment()])
+  }, [loadBuildEnvironment, refreshDeps])
 
   return (
     <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-3">
+        <Label>Build Environment</Label>
+        <Card size="sm">
+          <CardContent className="flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-sm">JUCE SDK</div>
+                <div className="text-xs text-muted-foreground">
+                  {buildEnvironment?.jucePath
+                    ? `${buildEnvironment.juceVersion} · ${buildEnvironment.juceSource === "override" ? "custom path" : "managed copy"}`
+                    : "Not configured"}
+                </div>
+              </div>
+              <Badge variant={buildEnvironment?.state === "ready" ? "default" : "destructive"}>
+                {isLoadingBuildEnvironment ? "Checking..." : buildEnvironment?.state === "ready" ? "Ready" : "Blocked"}
+              </Badge>
+            </div>
+
+            {buildEnvironment?.jucePath && (
+              <div className="text-xs font-mono text-muted-foreground break-all">
+                {buildEnvironment.jucePath}
+              </div>
+            )}
+
+            {buildEnvironment?.issues.length ? (
+              <div className="flex flex-col gap-2">
+                {buildEnvironment.issues.map((issue) => (
+                  <div key={issue.code} className="rounded-lg border border-border/60 bg-muted/40 p-3">
+                    <div className="text-sm">{issue.title}</div>
+                    <div className="text-xs text-muted-foreground mt-1">{issue.detail}</div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="text-xs text-muted-foreground">
+                The build toolchain and managed JUCE copy are ready.
+              </div>
+            )}
+
+            <div className="flex flex-wrap gap-2">
+              <Button variant="outline" size="sm" onClick={recheckEnvironment} disabled={isPreparingEnvironment}>
+                Re-check
+              </Button>
+              <Button size="sm" onClick={installManagedCopy} disabled={isPreparingEnvironment}>
+                {isPreparingEnvironment ? "Preparing..." : "Install Managed JUCE"}
+              </Button>
+              <Button variant="secondary" size="sm" onClick={chooseJuceFolder} disabled={isPreparingEnvironment}>
+                Choose JUCE Folder
+              </Button>
+              {buildEnvironment?.juceSource === "override" && (
+                <Button variant="ghost" size="sm" onClick={restoreManagedCopy} disabled={isPreparingEnvironment}>
+                  Use Managed Copy
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
       <div className="flex flex-col gap-3">
         <Label>Required</Label>
         <Card size="sm">
@@ -195,9 +300,13 @@ function DependenciesTab() {
                     <div className="text-sm">{dep.name}</div>
                     {dep.detail && <div className="text-xs text-muted-foreground truncate">{dep.detail}</div>}
                   </div>
-                  <Badge variant={dep.installed ? "default" : "destructive"}>
-                    {dep.installed ? "Installed" : "Missing"}
-                  </Badge>
+                  {optionalDeps.has(dep.name) && !dep.installed ? (
+                    <Badge variant="secondary">Optional</Badge>
+                  ) : (
+                    <Badge variant={dep.installed ? "default" : "destructive"}>
+                      {dep.installed ? "Installed" : "Missing"}
+                    </Badge>
+                  )}
                 </div>
               </div>
             ))}

--- a/src/pages/onboarding.tsx
+++ b/src/pages/onboarding.tsx
@@ -11,22 +11,52 @@ type DepStatus = "checking" | "installed" | "missing" | "installing" | "failed"
 interface Dep {
   name: string
   key: string
+  required: boolean
   status: DepStatus
   message?: string
 }
 
-const INITIAL_DEPS: Dep[] = [
-  { name: "Xcode Command Line Tools", key: "xcode_clt", status: "checking" },
-  { name: "CMake", key: "cmake", status: "checking" },
-  { name: "Claude Code CLI", key: "claude_code", status: "checking" },
-  { name: "Codex CLI", key: "codex", status: "checking" },
+const OPTIONAL_DEPENDENCIES = new Set(["Codex CLI"])
+
+const DEP_KEY_BY_NAME: Record<string, string> = {
+  "Xcode Command Line Tools": "xcode_clt",
+  "C++ Build Tools": "cpp_build_tools",
+  "CMake": "cmake",
+  "Claude Code CLI": "claude_code",
+  "Codex CLI": "codex",
+  "JUCE SDK": "juce",
+}
+
+const DEP_ORDER = [
+  "Xcode Command Line Tools",
+  "C++ Build Tools",
+  "CMake",
+  "Claude Code CLI",
+  "Codex CLI",
+  "JUCE SDK",
 ]
 
 const DEP_DESCRIPTIONS: Record<string, string> = {
-  xcode_clt: "C++ compiler and build tools from Apple",
-  cmake: "Cross-platform build system for JUCE projects",
-  claude_code: "AI coding agent that generates plugin source code",
-  codex: "OpenAI coding agent for plugin generation",
+  "Xcode Command Line Tools": "C++ compiler and Apple build tools",
+  "C++ Build Tools": "Visual Studio toolchain required to compile JUCE plugins",
+  "CMake": "Cross-platform build system for JUCE projects",
+  "Claude Code CLI": "Primary AI coding agent used for plugin generation",
+  "Codex CLI": "Optional OpenAI coding agent",
+  "JUCE SDK": "Framework used to compile the generated plugin",
+}
+
+function depSortOrder(name: string) {
+  const index = DEP_ORDER.indexOf(name)
+  return index === -1 ? DEP_ORDER.length : index
+}
+
+function mapDependency(result: Awaited<ReturnType<typeof commands.checkDependencies>>[number]): Dep {
+  return {
+    name: result.name,
+    key: DEP_KEY_BY_NAME[result.name] ?? result.name.toLowerCase().replace(/\s+/g, "_"),
+    required: !OPTIONAL_DEPENDENCIES.has(result.name),
+    status: result.installed ? "installed" : "missing",
+  }
 }
 
 function StatusDot({ status }: { status: DepStatus }) {
@@ -75,7 +105,7 @@ function StepIndicator({ current }: { current: OnboardingStep }) {
 
 export default function Onboarding() {
   const [step, setStep] = useState<OnboardingStep>("welcome")
-  const [deps, setDeps] = useState<Dep[]>(INITIAL_DEPS)
+  const [deps, setDeps] = useState<Dep[]>([])
   const [isInstallingAll, setIsInstallingAll] = useState(false)
   const [appeared, setAppeared] = useState(false)
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -99,25 +129,18 @@ export default function Onboarding() {
   const checkDeps = useCallback(async () => {
     try {
       const results = await commands.checkDependencies()
-      setDeps(prev =>
-        prev.map(dep => {
-          // Don't override if currently installing
-          if (dep.status === "installing") return dep
-          const match = results.find(r => {
-            if (dep.key === "xcode_clt") return r.name === "Xcode Command Line Tools"
-            if (dep.key === "cmake") return r.name === "CMake"
-            if (dep.key === "claude_code") return r.name === "Claude Code CLI"
-            if (dep.key === "codex") return r.name === "Codex CLI"
-            return false
-          })
-          if (!match) return { ...dep, status: dep.status === "installed" ? "installed" : "missing" as DepStatus }
-          return { ...dep, status: match.installed ? "installed" as DepStatus : "missing" as DepStatus }
-        })
-      )
+      const nextDeps = results
+        .map(mapDependency)
+        .sort((a, b) => depSortOrder(a.name) - depSortOrder(b.name))
+
+      setDeps(prev => nextDeps.map(dep => {
+        const current = prev.find(entry => entry.key === dep.key)
+        if (current?.status === "installing") return current
+        if (current?.status === "failed" && dep.status === "missing") return current
+        return dep
+      }))
     } catch {
-      setDeps(prev =>
-        prev.map(d => d.status === "checking" ? { ...d, status: "missing" as DepStatus } : d)
-      )
+      setDeps(prev => prev.map(d => d.status === "checking" ? { ...d, status: "missing" as DepStatus } : d))
     }
   }, [])
 
@@ -131,6 +154,19 @@ export default function Onboarding() {
     updateDep(key, { status: "installing", message: undefined })
 
     try {
+      if (key === "juce") {
+        const buildEnvironment = await commands.installJuce()
+        if (buildEnvironment.jucePath) {
+          await checkDeps()
+        } else {
+          updateDep(key, {
+            status: "failed",
+            message: buildEnvironment.issues[0]?.detail ?? "Failed to install JUCE.",
+          })
+        }
+        return
+      }
+
       const result = await commands.installDependency(key)
 
       if (key === "xcode_clt" && result.success) {
@@ -182,7 +218,8 @@ export default function Onboarding() {
     setIsInstallingAll(false)
   }, [deps, installSingle, checkDeps])
 
-  const allInstalled = deps.every(d => d.status === "installed")
+  const requiredDeps = deps.filter(d => d.required)
+  const allInstalled = requiredDeps.length > 0 && requiredDeps.every(d => d.status === "installed")
   const hasMissing = deps.some(d => d.status === "missing" || d.status === "failed")
   const isAnyInstalling = deps.some(d => d.status === "installing")
 
@@ -222,7 +259,7 @@ export default function Onboarding() {
               <h2 className="text-lg font-medium">Dependencies</h2>
               <p className="text-[12px] text-muted-foreground">
                 {allInstalled
-                  ? "All tools are installed. You're ready to go."
+                  ? "All required tools are installed. You're ready to go."
                   : "Install the required tools to get started."}
               </p>
             </div>
@@ -232,12 +269,15 @@ export default function Onboarding() {
                 <div key={dep.key} className="flex items-center gap-3 px-4 py-3 bg-muted/50">
                   <StatusDot status={dep.status} />
                   <div className="flex-1 min-w-0">
-                    <div className="text-[13px] text-foreground font-medium">{dep.name}</div>
+                    <div className="text-[13px] text-foreground font-medium">
+                      {dep.name}
+                      {!dep.required && <span className="ml-2 text-[10px] uppercase tracking-[1px] text-muted-foreground/60">Optional</span>}
+                    </div>
                     {dep.message ? (
                       <div className="text-[11px] text-amber-500 mt-0.5">{dep.message}</div>
                     ) : (
                       <div className="text-[11px] text-muted-foreground mt-0.5">
-                        {DEP_DESCRIPTIONS[dep.key]}
+                        {DEP_DESCRIPTIONS[dep.name] ?? "Required to generate and compile plugins."}
                       </div>
                     )}
                   </div>

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { Plugin, AuthState, UserProfile, PluginFilter } from "@/lib/types"
+import type { Plugin, AuthState, UserProfile, PluginFilter, RawUserProfile } from "@/lib/types"
 import * as commands from "@/lib/commands"
 
 export type MainView =
@@ -100,15 +100,18 @@ export const useAppStore = create<AppStore>((set, get) => ({
       const userId = await commands.checkSession();
       if (userId) {
         set({ authState: "authenticated" });
-        const profile = await commands.getProfile(userId);
+        const profile = await commands.getProfile(userId) as RawUserProfile | null;
         if (profile) {
           // Map snake_case from Supabase to camelCase
           const mapped: UserProfile = {
             ...profile,
+            id: profile.id ?? userId,
+            email: profile.email ?? "",
+            plan: profile.plan ?? "free",
             displayName: profile.display_name ?? profile.displayName,
             avatarUrl: profile.avatar_url ?? profile.avatarUrl,
             pluginsGenerated: profile.plugins_generated ?? profile.pluginsGenerated ?? 0,
-            createdAt: profile.created_at ?? profile.createdAt,
+            createdAt: profile.created_at ?? profile.createdAt ?? new Date(0).toISOString(),
             onboardingCompletedAt: profile.onboarding_completed_at ?? profile.onboardingCompletedAt,
             cardVariant: profile.card_variant ?? profile.cardVariant ?? "default",
           };


### PR DESCRIPTION
## Summary
- make the Tauri app Windows-aware across onboarding, install paths, plugin formats, and packaging
- add managed JUCE setup and platform-specific dependency handling for Windows
- add CI validation on macOS and Windows plus a manual workflow to build Windows installers

## Testing
- npm run build
- cargo check
- cargo check --target x86_64-pc-windows-msvc *(currently blocked on this macOS host by missing `llvm-rc` in tauri-winres, so final packaging validation is delegated to the Windows GitHub Actions runner)*