### PR TITLE
fix: align right header controls with sidebar on Windows

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -281,7 +281,7 @@ export default function App() {
         <div
           data-tauri-drag-region
           className="shrink-0 select-none flex items-end justify-end px-2 pb-1"
-          style={{ minHeight: Math.max(titlebarInset, 36) }}
+          style={{ minHeight: 52 }}
         >
           <TopNav />
         </div>


### PR DESCRIPTION
## Summary
- Right header controls (Builds, Profile, Settings) were misaligned with the sidebar header on Windows
- The right header used `Math.max(titlebarInset, 36)` which resolved to 36px on Windows (`titlebarInset=0`), while the sidebar header is always 52px
- Fixed by using a constant 52px height to match both sides on all platforms

## Test plan
- [ ] Verify header alignment on macOS (no visual change expected)
- [ ] Verify header alignment on Windows (right controls should now align with sidebar header)

Closes ME-59

🤖 Generated with [Claude Code](https://claude.com/claude-code)