### PR TITLE
fix: wire up CLI install buttons in Settings with toast feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foundry-tauri",
-  "version": "1.60.4",
+  "version": "1.61.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foundry-tauri",
-      "version": "1.60.4",
+      "version": "1.61.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@fontsource-variable/geist": "^5.2.8",
@@ -25,6 +25,7 @@
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.13.1",
         "shadcn": "^4.1.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
         "zod": "^4.3.6",
@@ -7569,6 +7570,16 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.1",
     "shadcn": "^4.1.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -10,6 +10,7 @@ import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar"
 import { Button } from "@/components/ui/button"
 import { PluginDetailView } from "@/components/app/plugin-detail-view"
 import { User, Bell, Hammer, Settings as SettingsIcon } from "lucide-react"
+import { Toaster } from "@/components/ui/sonner"
 import AuthContainer from "@/pages/auth/auth-container"
 import Onboarding from "@/pages/onboarding"
 import Prompt from "@/pages/prompt"
@@ -275,6 +276,7 @@ export default function App() {
     <SidebarProvider open={true}>
       <GlobalPipelineListener />
       <GlobalAppUpdateManager />
+      <Toaster position="bottom-right" />
       <AppSidebar />
       <SidebarInset className="min-w-0 overflow-hidden">
         {/* Drag region + top nav aligned to sidebar header */}

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,44 @@
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  return (
+    <Sonner
+      theme="dark"
+      className="toaster group"
+      icons={{
+        success: (
+          <CircleCheckIcon className="size-4" />
+        ),
+        info: (
+          <InfoIcon className="size-4" />
+        ),
+        warning: (
+          <TriangleAlertIcon className="size-4" />
+        ),
+        error: (
+          <OctagonXIcon className="size-4" />
+        ),
+        loading: (
+          <Loader2Icon className="size-4 animate-spin" />
+        ),
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react"
+import { toast } from "sonner"
 import { open } from "@tauri-apps/plugin-dialog"
 import { useAppStore } from "@/stores/app-store"
 import { useBuildStore } from "@/stores/build-store"
@@ -326,7 +327,38 @@ function GeneralTab() {
 
 function ModelsTab() {
   const { modelCatalog, loadCatalog, refreshModels, isRefreshing } = useSettingsStore()
+  const [installingCli, setInstallingCli] = useState<string | null>(null)
   useEffect(() => { loadCatalog() }, [loadCatalog])
+
+  const hasClaudeCode = modelCatalog.some((p) => p.name.toLowerCase().includes("claude"))
+  const hasCodex = modelCatalog.some((p) => p.name.toLowerCase().includes("codex"))
+
+  const handleInstallCli = useCallback(async (key: string) => {
+    const label = key === "claude_code" ? "Claude Code" : "Codex"
+    setInstallingCli(key)
+    try {
+      const result = await installDependency(key)
+      if (result.success) {
+        // Re-check auth state and launch auth if needed
+        const freshDeps = await invalidateAndCheckDependencies()
+        const depName = key === "claude_code" ? "Claude Code CLI" : "Codex CLI"
+        const providerStatus = freshDeps.find(d => d.name === depName)
+        if (providerStatus?.installed && providerStatus.authRequired) {
+          toast.info(`${label} installed — sign in to continue`, { description: "Opening browser…" })
+          if (key === "codex") await launchCodexAuth()
+          else await launchClaudeAuth()
+        } else {
+          toast.success(`${label} installed successfully`)
+        }
+        await refreshModels()
+      } else {
+        toast.error(`Failed to install ${label}`, { description: result.message })
+      }
+    } catch (e) {
+      toast.error(`Failed to install ${label}`, { description: String(e) })
+    }
+    setInstallingCli(null)
+  }, [refreshModels])
 
   return (
     <div className="flex flex-col gap-4">
@@ -362,6 +394,29 @@ function ModelsTab() {
         </div>
       ))}
 
+      {!hasClaudeCode && (
+        <div className="flex items-center gap-2 px-1 py-2">
+          <AgentIcon agent="Claude Code" className="size-3 text-muted-foreground/40" />
+          <span className="text-[10px] text-muted-foreground/50 flex-1">Claude Code CLI not installed</span>
+          <Button variant="outline" size="xs" disabled={installingCli !== null} onClick={() => handleInstallCli("claude_code")}>
+            {installingCli === "claude_code" ? (
+              <><div className="size-3 border-[1.5px] border-current border-t-transparent rounded-full animate-spin mr-1.5" />Installing…</>
+            ) : "Install"}
+          </Button>
+        </div>
+      )}
+
+      {!hasCodex && (
+        <div className="flex items-center gap-2 px-1 py-2">
+          <AgentIcon agent="Codex" className="size-3 text-muted-foreground/40" />
+          <span className="text-[10px] text-muted-foreground/50 flex-1">Codex CLI not installed</span>
+          <Button variant="outline" size="xs" disabled={installingCli !== null} onClick={() => handleInstallCli("codex")}>
+            {installingCli === "codex" ? (
+              <><div className="size-3 border-[1.5px] border-current border-t-transparent rounded-full animate-spin mr-1.5" />Installing…</>
+            ) : "Install"}
+          </Button>
+        </div>
+      )}
       <Button variant="outline" size="xs" onClick={refreshModels} disabled={isRefreshing} className="self-start">
         {isRefreshing ? "Refreshing..." : "Refresh Models"}
       </Button>
@@ -408,8 +463,15 @@ function DependenciesTab() {
     if (!key) return
     setInstalling(key)
     try {
-      await installDependency(key)
-    } catch {}
+      const result = await installDependency(key)
+      if (result.success) {
+        toast.success(`${dep.name} installed successfully`)
+      } else {
+        toast.error(`Failed to install ${dep.name}`, { description: result.message })
+      }
+    } catch (e) {
+      toast.error(`Failed to install ${dep.name}`, { description: String(e) })
+    }
     await refreshDeps()
     setInstalling(null)
   }, [refreshDeps])


### PR DESCRIPTION
## Summary
- **Settings > Models**: Install buttons for Claude Code and Codex now call `installDependency()` instead of opening external URLs (`window.open`)
- **Settings > Dependencies**: Install handler now surfaces success/error feedback via toasts
- Added `sonner` (via shadcn) as the toast system, mounted `<Toaster />` in `App.tsx`

Closes ME-55

## Test plan
- [ ] Open Settings > Models with no Codex installed, click Install → spinner appears, toast on success/error
- [ ] Open Settings > Dependencies, click Install on a missing dep → toast on success/error
- [ ] Verify toast appears bottom-right and auto-dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)