### PR TITLE
Add debug dependency reset in settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foundry-tauri",
-  "version": "1.61.4",
+  "version": "1.61.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foundry-tauri",
-      "version": "1.61.4",
+      "version": "1.61.6",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@fontsource-variable/geist": "^5.2.8",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "foundry"
-version = "1.61.4"
+version = "1.61.6"
 dependencies = [
  "chrono",
  "cocoa",

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -1,5 +1,5 @@
-use crate::state::AppState;
 use crate::services::telemetry_service;
+use crate::state::AppState;
 use tauri::{command, State};
 
 #[command]

--- a/src-tauri/src/commands/onboarding.rs
+++ b/src-tauri/src/commands/onboarding.rs
@@ -30,24 +30,32 @@ pub async fn install_dependency(
         ));
     }
 
-    let outcome = tokio::task::spawn_blocking(move || match name.as_str() {
-        "xcode_clt" => onboarding::DependencyInstallDispatchResult::Final(onboarding::install_xcode_clt()),
-        "cpp_build_tools" => {
-            onboarding::DependencyInstallDispatchResult::Final(onboarding::install_cpp_build_tools())
-        }
-        "cmake" => onboarding::DependencyInstallDispatchResult::Final(onboarding::install_cmake()),
-        "git" => onboarding::DependencyInstallDispatchResult::Final(onboarding::install_git()),
-        "claude_code" => onboarding::install_claude_code(),
-        "codex" => onboarding::install_codex(),
-        _ => onboarding::DependencyInstallDispatchResult::Final(onboarding::DependencyInstallResult::failed(
-            format!("Unknown dependency: {}", name),
-        )),
-    })
-    .await
-    .map_err(|e| {
-        onboarding::release_install_lock();
-        e.to_string()
-    })?;
+    let outcome =
+        tokio::task::spawn_blocking(move || match name.as_str() {
+            "xcode_clt" => {
+                onboarding::DependencyInstallDispatchResult::Final(onboarding::install_xcode_clt())
+            }
+            "cpp_build_tools" => onboarding::DependencyInstallDispatchResult::Final(
+                onboarding::install_cpp_build_tools(),
+            ),
+            "cmake" => {
+                onboarding::DependencyInstallDispatchResult::Final(onboarding::install_cmake())
+            }
+            "git" => onboarding::DependencyInstallDispatchResult::Final(onboarding::install_git()),
+            "claude_code" => onboarding::install_claude_code(),
+            "codex" => onboarding::install_codex(),
+            _ => onboarding::DependencyInstallDispatchResult::Final(
+                onboarding::DependencyInstallResult::failed(format!(
+                    "Unknown dependency: {}",
+                    name
+                )),
+            ),
+        })
+        .await
+        .map_err(|e| {
+            onboarding::release_install_lock();
+            e.to_string()
+        })?;
 
     // Invalidate cached shell environment so newly installed tools are detected
     platform::invalidate_shell_cache();
@@ -64,12 +72,31 @@ pub async fn install_dependency(
     Ok(result)
 }
 
+#[command]
+pub async fn reset_debug_dependencies() -> Result<onboarding::DependencyResetResult, String> {
+    if !onboarding::try_acquire_install_lock() {
+        return Err("Another dependency action is already in progress. Please wait.".into());
+    }
+
+    let result = tokio::task::spawn_blocking(onboarding::reset_debug_dependencies)
+        .await
+        .map_err(|e| {
+            onboarding::release_install_lock();
+            e.to_string()
+        })?;
+
+    onboarding::release_install_lock();
+    platform::invalidate_shell_cache();
+
+    Ok(result)
+}
+
 /// Launch `claude auth login` directly — opens the browser for OAuth.
 /// No terminal window needed.
 #[command]
 pub async fn launch_claude_auth() -> Result<bool, String> {
-    let claude_path = platform::resolve_claude_path()
-        .unwrap_or_else(|| platform::resolve_command("claude"));
+    let claude_path =
+        platform::resolve_claude_path().unwrap_or_else(|| platform::resolve_command("claude"));
 
     Command::new(&claude_path)
         .args(["auth", "login"])
@@ -82,8 +109,8 @@ pub async fn launch_claude_auth() -> Result<bool, String> {
 /// Launch `codex login` directly — opens the browser for OAuth.
 #[command]
 pub async fn launch_codex_auth() -> Result<bool, String> {
-    let codex_path = platform::resolve_codex_path()
-        .unwrap_or_else(|| platform::resolve_command("codex"));
+    let codex_path =
+        platform::resolve_codex_path().unwrap_or_else(|| platform::resolve_command("codex"));
 
     Command::new(&codex_path)
         .args(["login"])

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,6 +60,7 @@ pub fn run() {
             commands::onboarding::get_onboarding_state,
             commands::onboarding::complete_onboarding,
             commands::onboarding::install_dependency,
+            commands::onboarding::reset_debug_dependencies,
             commands::onboarding::launch_claude_auth,
             commands::onboarding::launch_codex_auth,
         ])

--- a/src-tauri/src/models/telemetry.rs
+++ b/src-tauri/src/models/telemetry.rs
@@ -397,16 +397,26 @@ mod tests {
         let v = t.agent_cli_version.unwrap();
         assert!(!v.is_empty(), "agent_cli_version must not be empty");
         // Must look like a semver string
-        assert!(v.contains('.'), "agent_cli_version must be a semver string, got: {}", v);
+        assert!(
+            v.contains('.'),
+            "agent_cli_version must be a semver string, got: {}",
+            v
+        );
     }
 
     #[test]
     fn telemetry_build_no_hardcoded_none_fields() {
         let t = make_builder().build();
         assert!(t.os_version.is_some(), "os_version must be detected");
-        assert!(t.cpu_architecture.is_some(), "cpu_architecture must be detected");
+        assert!(
+            t.cpu_architecture.is_some(),
+            "cpu_architecture must be detected"
+        );
         // user_rating starts as None — that's correct
-        assert!(t.user_rating.is_none(), "user_rating starts as None before user rates");
+        assert!(
+            t.user_rating.is_none(),
+            "user_rating starts as None before user rates"
+        );
     }
 
     #[test]

--- a/src-tauri/src/platform/macos.rs
+++ b/src-tauri/src/platform/macos.rs
@@ -10,10 +10,7 @@ static CLAUDE_PATH: RwLock<Option<Option<String>>> = RwLock::new(None);
 static CODEX_PATH: RwLock<Option<Option<String>>> = RwLock::new(None);
 
 fn resolve_shell_environment() -> Vec<(String, String)> {
-    let output = Command::new("/bin/zsh")
-        .args(["-lic", "env"])
-        .output()
-        .ok();
+    let output = Command::new("/bin/zsh").args(["-lic", "env"]).output().ok();
     let mut env = Vec::new();
     if let Some(out) = output {
         for line in String::from_utf8_lossy(&out.stdout).lines() {

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -94,7 +94,9 @@ pub fn default_plugin_install_dir(format: &PluginFormat) -> InstallDir {
 /// Returns the effective install directory, checking user overrides first.
 pub fn plugin_install_dir(format: &PluginFormat) -> InstallDir {
     if let Some(override_path) = crate::services::foundry_paths::install_path_override(format) {
-        return InstallDir { path: override_path };
+        return InstallDir {
+            path: override_path,
+        };
     }
     imp::plugin_install_dir(format)
 }
@@ -194,14 +196,18 @@ pub(crate) fn select_provider_resolution(
 }
 
 fn first_existing_path(paths: Vec<PathBuf>) -> Option<String> {
-    paths.into_iter()
+    paths
+        .into_iter()
         .find(|path| path.is_file())
         .map(|path| path.to_string_lossy().to_string())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{cli_shim_from_prefix, global_cli_path_from_npm_binary, select_provider_resolution, ProviderPlatform};
+    use super::{
+        cli_shim_from_prefix, global_cli_path_from_npm_binary, select_provider_resolution,
+        ProviderPlatform,
+    };
     use std::path::PathBuf;
 
     #[test]
@@ -210,12 +216,8 @@ mod tests {
         // internally, but verify the function produces the right structure
         let npm_dir = PathBuf::from("C:/Users/Theo/AppData/Roaming/npm");
         let npm_path = npm_dir.join("npm.cmd");
-        let path = global_cli_path_from_npm_binary(
-            npm_path,
-            "codex",
-            ProviderPlatform::Windows,
-        )
-        .unwrap();
+        let path =
+            global_cli_path_from_npm_binary(npm_path, "codex", ProviderPlatform::Windows).unwrap();
 
         let expected = npm_dir.join("codex.cmd");
         assert_eq!(path, expected);

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -376,7 +376,11 @@ fn provider_fallback_paths(command: &str) -> Vec<PathBuf> {
 
     if let Ok(appdata) = std::env::var("APPDATA") {
         if !appdata.is_empty() {
-            fallbacks.push(PathBuf::from(appdata).join("npm").join(format!("{}.cmd", command)));
+            fallbacks.push(
+                PathBuf::from(appdata)
+                    .join("npm")
+                    .join(format!("{}.cmd", command)),
+            );
         }
     }
 

--- a/src-tauri/src/services/build_environment.rs
+++ b/src-tauri/src/services/build_environment.rs
@@ -101,6 +101,32 @@ pub async fn clear_juce_override_path() -> Result<BuildEnvironmentStatus, String
     inspect_environment(false, None).await
 }
 
+pub fn reset_managed_juce_state() -> Result<Vec<String>, String> {
+    let mut actions = Vec::new();
+    let managed_root = foundry_paths::managed_juce_root_dir();
+
+    if managed_root.exists() {
+        fs::remove_dir_all(&managed_root).map_err(|error| error.to_string())?;
+        actions.push(format!("Removed {}", managed_root.display()));
+    }
+
+    let mut config = read_environment_config()?;
+    let had_override = config.juce_override_path.take().is_some();
+    let had_managed_version = config.managed_juce_version.take().is_some();
+    let had_last_resolved = config.last_resolved_juce_path.take().is_some();
+
+    if had_override {
+        actions.push("Cleared custom JUCE path override.".into());
+    }
+    config.last_validation_at = Some(Utc::now().to_rfc3339());
+
+    if had_override || had_managed_version || had_last_resolved || !actions.is_empty() {
+        write_environment_config(&config)?;
+    }
+
+    Ok(actions)
+}
+
 pub fn format_blocked_message(status: &BuildEnvironmentStatus) -> String {
     let details = status
         .issues

--- a/src-tauri/src/services/claude_code_service.rs
+++ b/src-tauri/src/services/claude_code_service.rs
@@ -1,6 +1,6 @@
-use std::process::Stdio;
 #[cfg(target_os = "windows")]
 use std::path::Path;
+use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
@@ -521,9 +521,7 @@ fn normalize_windows_git_bash_env(env: &mut [(String, String)]) -> Option<String
 
 #[cfg(any(test, target_os = "windows"))]
 fn normalize_windows_path(path: &str) -> String {
-    path.trim()
-        .trim_matches('"')
-        .replace('/', "\\")
+    path.trim().trim_matches('"').replace('/', "\\")
 }
 
 #[cfg(target_os = "windows")]
@@ -552,9 +550,7 @@ fn ensure_windows_project_settings(project_dir: &str, git_bash_path: &str) -> Re
         )
     })?;
 
-    let env = object
-        .entry("env")
-        .or_insert_with(|| serde_json::json!({}));
+    let env = object.entry("env").or_insert_with(|| serde_json::json!({}));
     let env_object = env.as_object_mut().ok_or_else(|| {
         format!(
             "{} must contain an object in the `env` field",

--- a/src-tauri/src/services/dependency_checker.rs
+++ b/src-tauri/src/services/dependency_checker.rs
@@ -59,7 +59,10 @@ fn check_codex_auth(explicit_path: Option<&str>) -> bool {
     }
 }
 
-fn check_dependency_with_path(spec: &platform::types::DependencySpec, explicit_path: Option<&str>) -> Option<String> {
+fn check_dependency_with_path(
+    spec: &platform::types::DependencySpec,
+    explicit_path: Option<&str>,
+) -> Option<String> {
     if spec.check_command == "__vs_build_tools__" {
         return platform::check_dependency(spec);
     }

--- a/src-tauri/src/services/foundry_paths.rs
+++ b/src-tauri/src/services/foundry_paths.rs
@@ -138,7 +138,7 @@ fn save_environment_config(config: &EnvironmentConfig) -> Result<(), String> {
     };
 
     std::fs::create_dir_all(parent).map_err(|e| format!("Failed to create config dir: {}", e))?;
-    let content =
-        serde_json::to_string_pretty(config).map_err(|e| format!("Failed to serialize config: {}", e))?;
+    let content = serde_json::to_string_pretty(config)
+        .map_err(|e| format!("Failed to serialize config: {}", e))?;
     std::fs::write(&config_path, content).map_err(|e| format!("Failed to write config: {}", e))
 }

--- a/src-tauri/src/services/generation_pipeline.rs
+++ b/src-tauri/src/services/generation_pipeline.rs
@@ -224,7 +224,8 @@ async fn execute_generation(
         },
     );
 
-    let build_entry = register_generation_build(&config, &plugin_name).map_err(|e| e.to_string())?;
+    let build_entry =
+        register_generation_build(&config, &plugin_name).map_err(|e| e.to_string())?;
     tb.plugin_id = Some(build_entry.id.clone());
     tb.version_number = Some(1);
     let _ = app.emit(
@@ -246,7 +247,11 @@ async fn execute_generation(
         }
     } else {
         emit_log(app, "Assembling project files...", None);
-        let pre_profile = infer_creative_profile(&plugin_name, &project_assembler::infer_plugin_type(&config.prompt), &config.prompt);
+        let pre_profile = infer_creative_profile(
+            &plugin_name,
+            &project_assembler::infer_plugin_type(&config.prompt),
+            &config.prompt,
+        );
         let creative_ctx = project_assembler::CreativeContext {
             signature_interaction: pre_profile.signature_interaction.to_string(),
             control_strategy: pre_profile.control_strategy.to_string(),
@@ -271,7 +276,8 @@ async fn execute_generation(
             Path::new(&resolved_juce_path),
             Some(&creative_ctx),
         )?;
-        persist_plugin_build_directory(&build_entry.id, &project.directory).map_err(|e| e.to_string())?;
+        persist_plugin_build_directory(&build_entry.id, &project.directory)
+            .map_err(|e| e.to_string())?;
         project
     };
 
@@ -310,20 +316,12 @@ async fn execute_generation(
 
     emit_log(
         app,
-        &format!(
-            "── {} · {} ──",
-            agent_display.to_lowercase(),
-            model_flag
-        ),
+        &format!("── {} · {} ──", agent_display.to_lowercase(), model_flag),
         Some("active"),
     );
 
-    let unified_prompt = build_unified_generation_prompt(
-        &plugin_name,
-        &config.prompt,
-        debug_context,
-        agent_name,
-    );
+    let unified_prompt =
+        build_unified_generation_prompt(&plugin_name, &config.prompt, debug_context, agent_name);
 
     let app_clone = app.clone();
     let gen_result = agent_service::run(
@@ -355,7 +353,10 @@ async fn execute_generation(
     // Only hard-fail if the agent produced zero source files — everything
     // else (missing UI files, style issues, etc.) will surface as compiler
     // errors and be handled by the build loop.
-    if !project.directory.join("Source/PluginProcessor.cpp").exists()
+    if !project
+        .directory
+        .join("Source/PluginProcessor.cpp")
+        .exists()
         && !project.directory.join("Source/PluginProcessor.h").exists()
     {
         let message = gen_result
@@ -887,7 +888,10 @@ fn random_icon_color() -> String {
     colors[rand_index(colors.len())].to_string()
 }
 
-fn register_generation_build(config: &GenerationConfig, plugin_name: &str) -> Result<Plugin, String> {
+fn register_generation_build(
+    config: &GenerationConfig,
+    plugin_name: &str,
+) -> Result<Plugin, String> {
     let mut plugins = plugin_manager::load_plugins().unwrap_or_default();
     let plugin_type = plugin_type_from_config(config);
     let formats = resolve_formats(&config.format);
@@ -968,12 +972,20 @@ fn reusable_build_directory(plugin: &Plugin) -> Option<PathBuf> {
         .filter(|path| path.exists())
 }
 
-fn persist_plugin_build_directory(plugin_id: &str, build_directory: &Path) -> Result<Plugin, String> {
+fn persist_plugin_build_directory(
+    plugin_id: &str,
+    build_directory: &Path,
+) -> Result<Plugin, String> {
     let mut plugins = plugin_manager::load_plugins().map_err(|e| e.to_string())?;
     let plugin = plugins
         .iter_mut()
         .find(|plugin| plugin.id == plugin_id)
-        .ok_or_else(|| format!("Plugin not found while saving build workspace: {}", plugin_id))?;
+        .ok_or_else(|| {
+            format!(
+                "Plugin not found while saving build workspace: {}",
+                plugin_id
+            )
+        })?;
     plugin.build_directory = Some(build_directory.to_string_lossy().to_string());
 
     let updated = plugin.clone();
@@ -3402,12 +3414,29 @@ mod tests {
     fn prompts_are_substantial() {
         let profile = CreativeProfile::for_prompt("a compressor", "effect");
         let processor = build_processor_prompt(
-            "Comp", "audio effect", "effect", "stereo", "a compressor", &profile, None,
+            "Comp",
+            "audio effect",
+            "effect",
+            "stereo",
+            "a compressor",
+            &profile,
+            None,
         );
         let ui = build_fast_ui_prompt(
-            "Comp", "audio effect", "effect", "a compressor", "stereo", &profile, &[], None,
+            "Comp",
+            "audio effect",
+            "effect",
+            "a compressor",
+            "stereo",
+            &profile,
+            &[],
+            None,
         );
-        assert!(processor.len() > 500, "processor prompt too short ({} chars)", processor.len());
+        assert!(
+            processor.len() > 500,
+            "processor prompt too short ({} chars)",
+            processor.len()
+        );
         assert!(ui.len() > 500, "UI prompt too short ({} chars)", ui.len());
     }
 }

--- a/src-tauri/src/services/onboarding.rs
+++ b/src-tauri/src/services/onboarding.rs
@@ -367,6 +367,22 @@ fn uninstall_provider_cli(
     }
 }
 
+#[cfg(target_os = "windows")]
+fn uninstall_cmake(items: &mut Vec<DependencyResetItem>) {
+    let cmake_path = platform::resolve_command("cmake");
+    let detail = if cmake_path == "cmake" {
+        "CMake is not reset on Windows by this debug action.".to_string()
+    } else {
+        format!(
+            "CMake is installed at {}. Windows debug reset leaves this install intact.",
+            cmake_path
+        )
+    };
+
+    push_reset_item(items, "CMake", DependencyResetStatus::Skipped, detail);
+}
+
+#[cfg(not(target_os = "windows"))]
 fn uninstall_cmake(items: &mut Vec<DependencyResetItem>) {
     let cmake_path = platform::resolve_command("cmake");
     let Some(brew_path) = resolve_brew_path() else {

--- a/src-tauri/src/services/onboarding.rs
+++ b/src-tauri/src/services/onboarding.rs
@@ -10,8 +10,7 @@ use crate::commands::dependencies::DependencyStatus;
 use crate::platform;
 use crate::services::{
     auth_service::{SupabaseAuth, SUPABASE_ANON_KEY, SUPABASE_URL},
-    dependency_checker,
-    foundry_paths,
+    build_environment, dependency_checker, foundry_paths,
 };
 
 /// Global lock: only one install can run at a time.
@@ -39,6 +38,19 @@ pub fn try_acquire_install_lock() -> bool {
 /// Release the install lock.
 pub fn release_install_lock() {
     INSTALL_ACTIVE.store(false, Ordering::SeqCst);
+}
+
+fn push_reset_item(
+    items: &mut Vec<DependencyResetItem>,
+    name: &str,
+    status: DependencyResetStatus,
+    detail: impl Into<String>,
+) {
+    items.push(DependencyResetItem {
+        name: name.to_string(),
+        status,
+        detail: detail.into(),
+    });
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -71,6 +83,29 @@ pub enum DependencyInstallVerification {
 pub enum DependencyInstallDispatchResult {
     Final(DependencyInstallResult),
     Provider(ProviderInstallPreparation),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DependencyResetStatus {
+    Removed,
+    Skipped,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DependencyResetItem {
+    pub name: String,
+    pub status: DependencyResetStatus,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DependencyResetResult {
+    pub items: Vec<DependencyResetItem>,
+    pub summary: String,
 }
 
 #[derive(Debug, Clone)]
@@ -141,6 +176,314 @@ impl DependencyInstallResult {
             detected_path: None,
         }
     }
+}
+
+fn resolve_provider_path(provider: ProviderCli) -> Option<String> {
+    match provider {
+        ProviderCli::Claude => platform::resolve_claude_path(),
+        ProviderCli::Codex => platform::resolve_codex_path(),
+    }
+}
+
+fn user_local_cli_path(path: &str, cli_name: &str) -> bool {
+    let cli_path = Path::new(path);
+    let Some(file_name) = cli_path.file_name().and_then(|value| value.to_str()) else {
+        return false;
+    };
+
+    #[cfg(target_os = "windows")]
+    let matches_name = file_name.eq_ignore_ascii_case(&format!("{}.cmd", cli_name));
+    #[cfg(not(target_os = "windows"))]
+    let matches_name = file_name == cli_name;
+
+    if !matches_name {
+        return false;
+    }
+
+    let Some(home) = dirs::home_dir() else {
+        return false;
+    };
+
+    [
+        home.join(".local").join("bin"),
+        home.join(".npm-global").join("bin"),
+    ]
+    .iter()
+    .any(|dir| cli_path.starts_with(dir))
+}
+
+fn npm_global_modules_dir(npm_path: &str) -> Result<PathBuf, String> {
+    let output = silent_command(npm_path)
+        .args(["root", "-g"])
+        .output()
+        .map_err(|e| format!("Failed to inspect npm global modules: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("npm root -g failed: {}", stderr.trim()));
+    }
+
+    let root = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if root.is_empty() {
+        return Err("npm root -g returned an empty path.".into());
+    }
+
+    Ok(PathBuf::from(root))
+}
+
+fn uninstall_global_npm_package(npm_path: &str, package_name: &str) -> Result<bool, String> {
+    let package_dir = npm_global_modules_dir(npm_path)?.join(package_name);
+    if !package_dir.exists() {
+        return Ok(false);
+    }
+
+    let output = silent_command(npm_path)
+        .args(["uninstall", "-g", package_name])
+        .output()
+        .map_err(|e| format!("Failed to uninstall {}: {}", package_name, e))?;
+
+    if output.status.success() {
+        Ok(true)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!(
+            "npm uninstall -g {} failed: {}",
+            package_name,
+            stderr.trim()
+        ))
+    }
+}
+
+fn uninstall_provider_cli(
+    provider: ProviderCli,
+    package_name: &str,
+    items: &mut Vec<DependencyResetItem>,
+) {
+    let dependency_name = provider.dependency_name();
+    let path_before = resolve_provider_path(provider);
+    let mut notes = Vec::new();
+    let mut removed_any = false;
+    let mut errors = Vec::new();
+
+    match resolve_npm_path() {
+        Some(npm_path) => match uninstall_global_npm_package(&npm_path, package_name) {
+            Ok(true) => {
+                removed_any = true;
+                notes.push(format!("Removed npm package {}.", package_name));
+            }
+            Ok(false) => {}
+            Err(error) => errors.push(error),
+        },
+        None => notes.push("npm was not available to remove global packages.".into()),
+    }
+
+    if let Err(error) = foundry_paths::clear_provider_path_override(provider.command()) {
+        errors.push(format!(
+            "Failed to clear {} path override: {}",
+            provider.command(),
+            error
+        ));
+    }
+
+    platform::invalidate_shell_cache();
+
+    if let Some(path) = resolve_provider_path(provider) {
+        if user_local_cli_path(&path, provider.command()) {
+            match std::fs::remove_file(&path) {
+                Ok(()) => {
+                    removed_any = true;
+                    notes.push(format!("Removed local CLI shim at {}.", path));
+                    platform::invalidate_shell_cache();
+                }
+                Err(error) => errors.push(format!("Failed to remove {}: {}", path, error)),
+            }
+        }
+    }
+
+    platform::invalidate_shell_cache();
+    let path_after = resolve_provider_path(provider);
+
+    if let Some(path) = path_after {
+        if errors.is_empty() {
+            let detail = if removed_any {
+                format!(
+                    "{} still resolves at {}. Foundry removed managed installs but left any external install intact.",
+                    dependency_name, path
+                )
+            } else {
+                format!(
+                    "{} is still installed at {}. No managed install was removed.",
+                    dependency_name, path
+                )
+            };
+            push_reset_item(
+                items,
+                dependency_name,
+                DependencyResetStatus::Skipped,
+                detail,
+            );
+        } else {
+            push_reset_item(
+                items,
+                dependency_name,
+                DependencyResetStatus::Failed,
+                errors.join(" "),
+            );
+        }
+        return;
+    }
+
+    if !errors.is_empty() {
+        push_reset_item(
+            items,
+            dependency_name,
+            DependencyResetStatus::Failed,
+            errors.join(" "),
+        );
+    } else if removed_any {
+        if notes.is_empty() {
+            notes.push(format!("Removed {}.", dependency_name));
+        }
+        push_reset_item(
+            items,
+            dependency_name,
+            DependencyResetStatus::Removed,
+            notes.join(" "),
+        );
+    } else if path_before.is_some() {
+        push_reset_item(
+            items,
+            dependency_name,
+            DependencyResetStatus::Removed,
+            format!("{} is no longer detected.", dependency_name),
+        );
+    } else {
+        push_reset_item(
+            items,
+            dependency_name,
+            DependencyResetStatus::Skipped,
+            format!("{} was not installed.", dependency_name),
+        );
+    }
+}
+
+fn uninstall_cmake(items: &mut Vec<DependencyResetItem>) {
+    let cmake_path = platform::resolve_command("cmake");
+    let Some(brew_path) = resolve_brew_path() else {
+        let detail = if cmake_path == "cmake" {
+            "Homebrew is not available and CMake is not currently detected.".to_string()
+        } else {
+            format!(
+                "CMake is installed at {} but not via a removable Homebrew setup.",
+                cmake_path
+            )
+        };
+        push_reset_item(items, "CMake", DependencyResetStatus::Skipped, detail);
+        return;
+    };
+
+    let list_output = silent_command(&brew_path)
+        .args(["list", "--versions", "cmake"])
+        .output();
+
+    let installed_via_brew = matches!(list_output, Ok(output) if output.status.success() && !String::from_utf8_lossy(&output.stdout).trim().is_empty());
+
+    if !installed_via_brew {
+        let detail = if cmake_path == "cmake" {
+            "CMake is not installed via Homebrew.".to_string()
+        } else {
+            format!(
+                "CMake is installed at {} but not via Homebrew, so it was left intact.",
+                cmake_path
+            )
+        };
+        push_reset_item(items, "CMake", DependencyResetStatus::Skipped, detail);
+        return;
+    }
+
+    let output = silent_command(&brew_path)
+        .args(["uninstall", "cmake"])
+        .output();
+
+    match output {
+        Ok(result) if result.status.success() => push_reset_item(
+            items,
+            "CMake",
+            DependencyResetStatus::Removed,
+            "Removed Homebrew CMake install.",
+        ),
+        Ok(result) => {
+            let stderr = String::from_utf8_lossy(&result.stderr);
+            push_reset_item(
+                items,
+                "CMake",
+                DependencyResetStatus::Failed,
+                format!("Homebrew uninstall failed: {}", stderr.trim()),
+            );
+        }
+        Err(error) => push_reset_item(
+            items,
+            "CMake",
+            DependencyResetStatus::Failed,
+            format!("Failed to launch Homebrew uninstall: {}", error),
+        ),
+    }
+}
+
+pub fn reset_debug_dependencies() -> DependencyResetResult {
+    let mut items = Vec::new();
+
+    platform::invalidate_shell_cache();
+    uninstall_provider_cli(ProviderCli::Claude, "@anthropic-ai/claude-code", &mut items);
+    uninstall_provider_cli(ProviderCli::Codex, "@openai/codex", &mut items);
+    uninstall_cmake(&mut items);
+
+    match build_environment::reset_managed_juce_state() {
+        Ok(actions) if actions.is_empty() => push_reset_item(
+            &mut items,
+            "JUCE SDK",
+            DependencyResetStatus::Skipped,
+            "No managed JUCE install was present.",
+        ),
+        Ok(actions) => push_reset_item(
+            &mut items,
+            "JUCE SDK",
+            DependencyResetStatus::Removed,
+            actions.join(" "),
+        ),
+        Err(error) => push_reset_item(&mut items, "JUCE SDK", DependencyResetStatus::Failed, error),
+    }
+
+    push_reset_item(
+        &mut items,
+        "Xcode Command Line Tools",
+        DependencyResetStatus::Skipped,
+        "Left intact because it is a system toolchain install.",
+    );
+
+    platform::invalidate_shell_cache();
+
+    let removed = items
+        .iter()
+        .filter(|item| item.status == DependencyResetStatus::Removed)
+        .count();
+    let failed = items
+        .iter()
+        .filter(|item| item.status == DependencyResetStatus::Failed)
+        .count();
+
+    let summary = if failed > 0 {
+        format!(
+            "Dependency reset finished with {} removal(s) and {} failure(s).",
+            removed, failed
+        )
+    } else if removed > 0 {
+        format!("Removed {} dependency install(s).", removed)
+    } else {
+        "No removable dependency installs were found.".to_string()
+    };
+
+    DependencyResetResult { items, summary }
 }
 
 /// Read onboarding state from the user's Supabase profile.
@@ -236,7 +579,9 @@ pub fn install_xcode_clt() -> DependencyInstallResult {
             Ok(o) => {
                 let stderr = String::from_utf8_lossy(&o.stderr);
                 if stderr.contains("already installed") {
-                    DependencyInstallResult::verified("Xcode Command Line Tools are already installed.")
+                    DependencyInstallResult::verified(
+                        "Xcode Command Line Tools are already installed.",
+                    )
                 } else {
                     DependencyInstallResult::pending(
                         "Xcode Command Line Tools installer launched. Please complete the installation in the popup window.",
@@ -277,8 +622,12 @@ fn resolve_npm_path() -> Option<String> {
         let program_files = std::env::var("ProgramFiles").unwrap_or_default();
         let appdata = std::env::var("APPDATA").unwrap_or_default();
         for candidate in &[
-            std::path::PathBuf::from(&program_files).join("nodejs").join("npm.cmd"),
-            std::path::PathBuf::from(&appdata).join("npm").join("npm.cmd"),
+            std::path::PathBuf::from(&program_files)
+                .join("nodejs")
+                .join("npm.cmd"),
+            std::path::PathBuf::from(&appdata)
+                .join("npm")
+                .join("npm.cmd"),
         ] {
             if candidate.is_file() {
                 return Some(candidate.to_string_lossy().to_string());
@@ -425,9 +774,10 @@ fn run_winget_install(
                 ))
             }
         }
-        Err(error) => {
-            DependencyInstallResult::failed(format!("Could not install {}: {}", display_name, error))
-        }
+        Err(error) => DependencyInstallResult::failed(format!(
+            "Could not install {}: {}",
+            display_name, error
+        )),
     }
 }
 
@@ -488,40 +838,43 @@ pub fn install_cmake() -> DependencyInstallResult {
 
     #[cfg(not(target_os = "windows"))]
     {
-    let brew = match resolve_brew_path() {
-        Some(path) => path,
-        None => {
-            if let Err(e) = install_homebrew() {
-                return DependencyInstallResult::failed(e);
-            }
-            match resolve_brew_path() {
-                Some(path) => path,
-                None => {
-                    return DependencyInstallResult::failed(
-                        "Homebrew installed but could not be found on PATH.",
-                    )
+        let brew = match resolve_brew_path() {
+            Some(path) => path,
+            None => {
+                if let Err(e) = install_homebrew() {
+                    return DependencyInstallResult::failed(e);
+                }
+                match resolve_brew_path() {
+                    Some(path) => path,
+                    None => {
+                        return DependencyInstallResult::failed(
+                            "Homebrew installed but could not be found on PATH.",
+                        )
+                    }
                 }
             }
-        }
-    };
+        };
 
-    let result = silent_command(&brew).args(["install", "cmake"]).output();
+        let result = silent_command(&brew).args(["install", "cmake"]).output();
 
-    match result {
-        Ok(o) if o.status.success() => {
-            DependencyInstallResult::verified("CMake installed successfully via Homebrew.")
-        }
-        Ok(o) => {
-            let stderr = String::from_utf8_lossy(&o.stderr);
-            let stdout = String::from_utf8_lossy(&o.stdout);
-            if stderr.contains("already installed") || stdout.contains("already installed") {
-                DependencyInstallResult::verified("CMake is already installed via Homebrew.")
-            } else {
-                DependencyInstallResult::failed(format!("Failed to install CMake: {}", stderr.trim()))
+        match result {
+            Ok(o) if o.status.success() => {
+                DependencyInstallResult::verified("CMake installed successfully via Homebrew.")
             }
+            Ok(o) => {
+                let stderr = String::from_utf8_lossy(&o.stderr);
+                let stdout = String::from_utf8_lossy(&o.stdout);
+                if stderr.contains("already installed") || stdout.contains("already installed") {
+                    DependencyInstallResult::verified("CMake is already installed via Homebrew.")
+                } else {
+                    DependencyInstallResult::failed(format!(
+                        "Failed to install CMake: {}",
+                        stderr.trim()
+                    ))
+                }
+            }
+            Err(e) => DependencyInstallResult::failed(format!("Failed to run brew: {}", e)),
         }
-        Err(e) => DependencyInstallResult::failed(format!("Failed to run brew: {}", e)),
-    }
     }
 }
 
@@ -634,7 +987,9 @@ fn format_vs_build_tools_failure(exit_code: Option<i32>) -> String {
 pub fn install_cpp_build_tools() -> DependencyInstallResult {
     #[cfg(not(target_os = "windows"))]
     {
-        DependencyInstallResult::failed("C++ Build Tools installation is only available on Windows.")
+        DependencyInstallResult::failed(
+            "C++ Build Tools installation is only available on Windows.",
+        )
     }
 
     #[cfg(target_os = "windows")]
@@ -671,7 +1026,9 @@ pub fn install_cpp_build_tools() -> DependencyInstallResult {
                 let install_succeeded = matches!(exit_code, Some(0) | Some(1641) | Some(3010));
 
                 if !install_succeeded {
-                    return DependencyInstallResult::failed(format_vs_build_tools_failure(exit_code));
+                    return DependencyInstallResult::failed(format_vs_build_tools_failure(
+                        exit_code,
+                    ));
                 }
 
                 if wait_for_vs_build_tools_registration(30) {
@@ -693,9 +1050,10 @@ pub fn install_cpp_build_tools() -> DependencyInstallResult {
                     DependencyInstallResult::failed("Build Tools installation finished, but Foundry could not verify the C++ workload afterwards. Restart Foundry and click Re-check.")
                 }
             }
-            Err(e) => {
-                DependencyInstallResult::failed(format!("Could not launch the Build Tools installer: {}", e))
-            }
+            Err(e) => DependencyInstallResult::failed(format!(
+                "Could not launch the Build Tools installer: {}",
+                e
+            )),
         }
     }
 }
@@ -840,7 +1198,10 @@ fn verified_provider_result(
         DependencyInstallVerification::Verified
     };
     let message = if status.auth_required {
-        format!("{} installed. Sign in to continue.", provider.display_name())
+        format!(
+            "{} installed. Sign in to continue.",
+            provider.display_name()
+        )
     } else {
         format!("{} installed successfully.", provider.display_name())
     };
@@ -912,10 +1273,9 @@ pub async fn verify_provider_install(
                 path
             );
 
-            if let Some(status) = dependency_checker::provider_status(
-                preparation.provider,
-                Some(&path),
-            )? {
+            if let Some(status) =
+                dependency_checker::provider_status(preparation.provider, Some(&path))?
+            {
                 foundry_paths::set_provider_path_override(preparation.provider.command(), &path)?;
                 platform::invalidate_shell_cache();
 
@@ -951,7 +1311,10 @@ pub async fn verify_provider_install(
 
 #[cfg(test)]
 mod tests {
-    use super::{provider_not_detected_result, DependencyInstallVerification, ProviderCli};
+    use super::{
+        provider_not_detected_result, user_local_cli_path, DependencyInstallVerification,
+        DependencyResetItem, DependencyResetResult, DependencyResetStatus, ProviderCli,
+    };
 
     #[test]
     fn verification_timeout_returns_not_detected() {
@@ -961,9 +1324,55 @@ mod tests {
         );
 
         assert!(!result.success);
-        assert_eq!(result.verification, DependencyInstallVerification::NotDetected);
-        assert_eq!(result.detected_path.as_deref(), Some("/opt/homebrew/bin/codex"));
-        assert!(result.message.contains("could not verify the CLI afterwards"));
+        assert_eq!(
+            result.verification,
+            DependencyInstallVerification::NotDetected
+        );
+        assert_eq!(
+            result.detected_path.as_deref(),
+            Some("/opt/homebrew/bin/codex")
+        );
+        assert!(result
+            .message
+            .contains("could not verify the CLI afterwards"));
+    }
+
+    #[test]
+    fn reset_summary_counts_removed_and_failed_items() {
+        let result = DependencyResetResult {
+            items: vec![
+                DependencyResetItem {
+                    name: "Claude Code CLI".into(),
+                    status: DependencyResetStatus::Removed,
+                    detail: "Removed.".into(),
+                },
+                DependencyResetItem {
+                    name: "JUCE SDK".into(),
+                    status: DependencyResetStatus::Failed,
+                    detail: "Could not remove.".into(),
+                },
+            ],
+            summary: "Dependency reset finished with 1 removal(s) and 1 failure(s).".into(),
+        };
+
+        assert!(result.summary.contains("1 removal"));
+        assert!(result.summary.contains("1 failure"));
+    }
+
+    #[test]
+    fn only_user_local_bins_are_treated_as_directly_removable() {
+        let home = dirs::home_dir().unwrap();
+        let local_path = home.join(".local/bin/claude");
+        let homebrew_path = std::path::PathBuf::from("/opt/homebrew/bin/claude");
+
+        assert!(user_local_cli_path(
+            local_path.to_string_lossy().as_ref(),
+            "claude"
+        ));
+        assert!(!user_local_cli_path(
+            homebrew_path.to_string_lossy().as_ref(),
+            "claude"
+        ));
     }
 }
 

--- a/src-tauri/src/services/onboarding.rs
+++ b/src-tauri/src/services/onboarding.rs
@@ -1378,7 +1378,14 @@ mod tests {
     #[test]
     fn only_user_local_bins_are_treated_as_directly_removable() {
         let home = dirs::home_dir().unwrap();
+        #[cfg(target_os = "windows")]
+        let local_path = home.join(".local/bin/claude.cmd");
+        #[cfg(not(target_os = "windows"))]
         let local_path = home.join(".local/bin/claude");
+
+        #[cfg(target_os = "windows")]
+        let homebrew_path = std::path::PathBuf::from("C:/Program Files/claude.cmd");
+        #[cfg(not(target_os = "windows"))]
         let homebrew_path = std::path::PathBuf::from("/opt/homebrew/bin/claude");
 
         assert!(user_local_cli_path(

--- a/src-tauri/src/services/project_assembler.rs
+++ b/src-tauri/src/services/project_assembler.rs
@@ -330,7 +330,6 @@ fn infer_interface_style(prompt: &str, plugin_type: &str) -> &'static str {
     }
 }
 
-
 fn select_skills_for_type(plugin_type: &str) -> String {
     let juce_expert = include_str!("../../../foundry-kit/skills/juce-expert/SKILL.md");
     let art_director = include_str!("../../../foundry-kit/skills/art-director/SKILL.md");
@@ -552,7 +551,6 @@ juce_generate_juce_header({name})
 
     fs::write(dir.join("CMakeLists.txt"), content).map_err(|e| e.to_string())
 }
-
 
 fn write_foundry_kit(project_dir: &Path) -> Result<(), String> {
     let kit_dir = project_dir.join("foundry-kit");

--- a/src-tauri/src/services/telemetry_service.rs
+++ b/src-tauri/src/services/telemetry_service.rs
@@ -18,7 +18,9 @@ pub fn save(telemetry: &GenerationTelemetry, auth: &SupabaseAuth) {
     let session = auth.get_session();
     tokio::spawn(async move {
         if let Some(session) = session {
-            if let SyncOutcome::PermanentError = sync_to_supabase(&telemetry, &session.user_id, &session.access_token).await {
+            if let SyncOutcome::PermanentError =
+                sync_to_supabase(&telemetry, &session.user_id, &session.access_token).await
+            {
                 mark_sync_skip(&telemetry.id);
             }
         } else {
@@ -89,7 +91,9 @@ pub fn sync_local_backlog(auth: &SupabaseAuth) {
             match sync_to_supabase(&telemetry, &session.user_id, &session.access_token).await {
                 SyncOutcome::Success => synced += 1,
                 SyncOutcome::AuthExpired => {
-                    log::warn!("[Telemetry] Backlog sync aborted: JWT expired. Will retry after re-auth.");
+                    log::warn!(
+                        "[Telemetry] Backlog sync aborted: JWT expired. Will retry after re-auth."
+                    );
                     break;
                 }
                 SyncOutcome::PermanentError => {
@@ -108,7 +112,10 @@ pub fn sync_local_backlog(auth: &SupabaseAuth) {
     });
 }
 
-fn normalize_telemetry(mut telemetry: GenerationTelemetry, plugins: &[Plugin]) -> GenerationTelemetry {
+fn normalize_telemetry(
+    mut telemetry: GenerationTelemetry,
+    plugins: &[Plugin],
+) -> GenerationTelemetry {
     if missing_string(telemetry.plugin_type.as_deref()) {
         telemetry.plugin_type = infer_plugin_type(&telemetry, plugins);
     }
@@ -158,12 +165,22 @@ fn missing_string(value: Option<&str>) -> bool {
 fn infer_plugin_type(telemetry: &GenerationTelemetry, plugins: &[Plugin]) -> Option<String> {
     plugin_from_telemetry(telemetry, plugins)
         .map(|plugin| plugin_type_label(&plugin.plugin_type).to_string())
-        .or_else(|| Some(project_assembler::infer_plugin_type(&telemetry.original_prompt)))
+        .or_else(|| {
+            Some(project_assembler::infer_plugin_type(
+                &telemetry.original_prompt,
+            ))
+        })
 }
 
-fn plugin_format_from_plugins(telemetry: &GenerationTelemetry, plugins: &[Plugin]) -> Option<String> {
+fn plugin_format_from_plugins(
+    telemetry: &GenerationTelemetry,
+    plugins: &[Plugin],
+) -> Option<String> {
     let plugin = plugin_from_telemetry(telemetry, plugins)?;
-    let has_au = plugin.formats.iter().any(|format| matches!(format, PluginFormat::Au));
+    let has_au = plugin
+        .formats
+        .iter()
+        .any(|format| matches!(format, PluginFormat::Au));
     let has_vst3 = plugin
         .formats
         .iter()
@@ -238,7 +255,8 @@ fn estimate_codex_cost_usd(
         _ => return None,
     };
 
-    let has_usage = input_tokens.is_some() || output_tokens.is_some() || cache_read_tokens.is_some();
+    let has_usage =
+        input_tokens.is_some() || output_tokens.is_some() || cache_read_tokens.is_some();
     if !has_usage {
         return None;
     }
@@ -279,7 +297,11 @@ fn detect_os_version() -> String {
                 content
                     .lines()
                     .find(|line| line.starts_with("PRETTY_NAME="))
-                    .map(|line| line.trim_start_matches("PRETTY_NAME=").trim_matches('"').to_string())
+                    .map(|line| {
+                        line.trim_start_matches("PRETTY_NAME=")
+                            .trim_matches('"')
+                            .to_string()
+                    })
             })
             .unwrap_or_else(|| "Linux".to_string())
     }
@@ -345,7 +367,8 @@ async fn sync_to_supabase(
                     400 | 403 => {
                         log::error!(
                             "[Telemetry] Permanent failure for {} — will not retry: {}",
-                            telemetry.id, body
+                            telemetry.id,
+                            body
                         );
                         SyncOutcome::PermanentError
                     }

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -4,7 +4,8 @@ import {
   BuildEnvironmentStatusSchema,
   OnboardingStateSchema,
   DependencyInstallResultSchema,
-} from "@/lib/schemas"
+  DependencyResetResultSchema,
+} from "@/lib/schemas";
 import type {
   Plugin,
   GenerationConfig,
@@ -17,7 +18,8 @@ import type {
   RawUserProfile,
   OnboardingState,
   DependencyInstallResult,
-} from "@/lib/types"
+  DependencyResetResult,
+} from "@/lib/types";
 
 export const sendOtp = (email: string) => invoke<void>("send_otp", { email });
 export const verifyOtp = (email: string, code: string, isSignup: boolean) =>
@@ -34,7 +36,8 @@ export const assignCardVariantBatch = (emails: string[], variant: string) =>
   invoke<number>("assign_card_variant_batch", { emails, variant });
 
 export const loadPlugins = () => invoke<Plugin[]>("load_plugins");
-export const deletePlugin = (id: string) => invoke<void>("delete_plugin", { id });
+export const deletePlugin = (id: string) =>
+  invoke<void>("delete_plugin", { id });
 export const renamePlugin = (id: string, newName: string) =>
   invoke<void>("rename_plugin", { id, newName });
 export const installVersion = (pluginId: string, versionNumber: number) =>
@@ -55,8 +58,12 @@ export const cancelBuild = () => invoke<void>("cancel_build");
 export const checkDependencies = async (): Promise<DependencyStatus[]> =>
   DependencyStatusArraySchema.parse(await invoke("check_dependencies"));
 
-export const invalidateAndCheckDependencies = async (): Promise<DependencyStatus[]> =>
-  DependencyStatusArraySchema.parse(await invoke("invalidate_and_check_dependencies"));
+export const invalidateAndCheckDependencies = async (): Promise<
+  DependencyStatus[]
+> =>
+  DependencyStatusArraySchema.parse(
+    await invoke("invalidate_and_check_dependencies"),
+  );
 
 export const installJuce = async (): Promise<BuildEnvironmentStatus> =>
   BuildEnvironmentStatusSchema.parse(await invoke("install_juce"));
@@ -64,14 +71,25 @@ export const installJuce = async (): Promise<BuildEnvironmentStatus> =>
 export const getBuildEnvironment = async (): Promise<BuildEnvironmentStatus> =>
   BuildEnvironmentStatusSchema.parse(await invoke("get_build_environment"));
 
-export const prepareBuildEnvironment = async (autoRepair: boolean): Promise<BuildEnvironmentStatus> =>
-  BuildEnvironmentStatusSchema.parse(await invoke("prepare_build_environment", { autoRepair }));
+export const prepareBuildEnvironment = async (
+  autoRepair: boolean,
+): Promise<BuildEnvironmentStatus> =>
+  BuildEnvironmentStatusSchema.parse(
+    await invoke("prepare_build_environment", { autoRepair }),
+  );
 
-export const setJuceOverridePath = async (path: string): Promise<BuildEnvironmentStatus> =>
-  BuildEnvironmentStatusSchema.parse(await invoke("set_juce_override_path", { path }));
+export const setJuceOverridePath = async (
+  path: string,
+): Promise<BuildEnvironmentStatus> =>
+  BuildEnvironmentStatusSchema.parse(
+    await invoke("set_juce_override_path", { path }),
+  );
 
-export const clearJuceOverridePath = async (): Promise<BuildEnvironmentStatus> =>
-  BuildEnvironmentStatusSchema.parse(await invoke("clear_juce_override_path"));
+export const clearJuceOverridePath =
+  async (): Promise<BuildEnvironmentStatus> =>
+    BuildEnvironmentStatusSchema.parse(
+      await invoke("clear_juce_override_path"),
+    );
 
 export const getOnboardingState = async (): Promise<OnboardingState> =>
   OnboardingStateSchema.parse(await invoke("get_onboarding_state"));
@@ -79,8 +97,16 @@ export const getOnboardingState = async (): Promise<OnboardingState> =>
 export const completeOnboarding = async (): Promise<OnboardingState> =>
   OnboardingStateSchema.parse(await invoke("complete_onboarding"));
 
-export const installDependency = async (name: string): Promise<DependencyInstallResult> =>
-  DependencyInstallResultSchema.parse(await invoke("install_dependency", { name }));
+export const installDependency = async (
+  name: string,
+): Promise<DependencyInstallResult> =>
+  DependencyInstallResultSchema.parse(
+    await invoke("install_dependency", { name }),
+  );
+
+export const resetDebugDependencies =
+  async (): Promise<DependencyResetResult> =>
+    DependencyResetResultSchema.parse(await invoke("reset_debug_dependencies"));
 
 export const launchClaudeAuth = () => invoke<boolean>("launch_claude_auth");
 export const launchCodexAuth = () => invoke<boolean>("launch_codex_auth");
@@ -89,8 +115,10 @@ export const launchCodexAuth = () => invoke<boolean>("launch_codex_auth");
 // Models & install paths (no Zod — not in onboarding critical path)
 // ---------------------------------------------------------------------------
 
-export const getModelCatalog = () => invoke<AgentProvider[]>("get_model_catalog");
-export const refreshModelCatalog = () => invoke<AgentProvider[]>("refresh_model_catalog");
+export const getModelCatalog = () =>
+  invoke<AgentProvider[]>("get_model_catalog");
+export const refreshModelCatalog = () =>
+  invoke<AgentProvider[]>("refresh_model_catalog");
 
 export interface InstallPathsConfig {
   platform: "macos" | "windows" | "linux";
@@ -101,7 +129,8 @@ export interface InstallPathsConfig {
   vst3IsDefault: boolean;
 }
 
-export const getInstallPaths = () => invoke<InstallPathsConfig>("get_install_paths");
+export const getInstallPaths = () =>
+  invoke<InstallPathsConfig>("get_install_paths");
 export const setInstallPath = (format: string, path: string) =>
   invoke<InstallPathsConfig>("set_install_path", { format, path });
 export const resetInstallPath = (format: string) =>
@@ -110,11 +139,18 @@ export const resetInstallPath = (format: string) =>
 export const rateGeneration = (id: string, rating: 1 | -1) =>
   invoke<void>("rate_generation", { id, rating });
 
-export const submitPluginFeedback = (pluginId: string, speed: number, quality: number, design: number) =>
+export const submitPluginFeedback = (
+  pluginId: string,
+  speed: number,
+  quality: number,
+  design: number,
+) =>
   invoke<void>("submit_plugin_feedback", { pluginId, speed, quality, design });
 
 export const loadTelemetry = (id: string) =>
   invoke<GenerationTelemetry | null>("load_telemetry", { id });
-export const loadAllTelemetry = () => invoke<GenerationTelemetry[]>("load_all_telemetry");
+export const loadAllTelemetry = () =>
+  invoke<GenerationTelemetry[]>("load_all_telemetry");
 
-export const showInFinder = (path: string) => invoke<void>("show_in_finder", { path });
+export const showInFinder = (path: string) =>
+  invoke<void>("show_in_finder", { path });

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from "zod"
+import { z } from "zod";
 
 // ---------------------------------------------------------------------------
 // Dependency & onboarding schemas — validate data at the Tauri IPC boundary
@@ -10,9 +10,9 @@ export const DependencyStatusSchema = z.object({
   authRequired: z.boolean(),
   detail: z.string().nullish(),
   version: z.string().nullish(),
-})
+});
 
-export const DependencyStatusArraySchema = z.array(DependencyStatusSchema)
+export const DependencyStatusArraySchema = z.array(DependencyStatusSchema);
 
 export const BuildEnvironmentIssueSchema = z.object({
   code: z.string(),
@@ -20,7 +20,7 @@ export const BuildEnvironmentIssueSchema = z.object({
   detail: z.string(),
   recoverable: z.boolean(),
   actionLabel: z.string().nullish(),
-})
+});
 
 export const BuildEnvironmentStatusSchema = z.object({
   state: z.enum(["ready", "repairing", "blocked"]),
@@ -28,27 +28,49 @@ export const BuildEnvironmentStatusSchema = z.object({
   juceSource: z.enum(["managed", "override"]).nullish(),
   jucePath: z.string().nullish(),
   juceVersion: z.string(),
-})
+});
 
 export const OnboardingStateSchema = z.object({
   completed: z.boolean(),
   completedAt: z.string().nullish(),
-})
+});
 
 export const DependencyInstallResultSchema = z.object({
   success: z.boolean(),
   message: z.string(),
-  verification: z.enum(["verified", "auth_required", "pending", "not_detected"]),
+  verification: z.enum([
+    "verified",
+    "auth_required",
+    "pending",
+    "not_detected",
+  ]),
   status: DependencyStatusSchema.nullish(),
   detectedPath: z.string().nullish(),
-})
+});
+
+export const DependencyResetItemSchema = z.object({
+  name: z.string().min(1),
+  status: z.enum(["removed", "skipped", "failed"]),
+  detail: z.string(),
+});
+
+export const DependencyResetResultSchema = z.object({
+  items: z.array(DependencyResetItemSchema),
+  summary: z.string(),
+});
 
 // ---------------------------------------------------------------------------
 // Inferred types — use these instead of the manual interfaces
 // ---------------------------------------------------------------------------
 
-export type DependencyStatus = z.infer<typeof DependencyStatusSchema>
-export type BuildEnvironmentIssue = z.infer<typeof BuildEnvironmentIssueSchema>
-export type BuildEnvironmentStatus = z.infer<typeof BuildEnvironmentStatusSchema>
-export type OnboardingState = z.infer<typeof OnboardingStateSchema>
-export type DependencyInstallResult = z.infer<typeof DependencyInstallResultSchema>
+export type DependencyStatus = z.infer<typeof DependencyStatusSchema>;
+export type BuildEnvironmentIssue = z.infer<typeof BuildEnvironmentIssueSchema>;
+export type BuildEnvironmentStatus = z.infer<
+  typeof BuildEnvironmentStatusSchema
+>;
+export type OnboardingState = z.infer<typeof OnboardingStateSchema>;
+export type DependencyInstallResult = z.infer<
+  typeof DependencyInstallResultSchema
+>;
+export type DependencyResetItem = z.infer<typeof DependencyResetItemSchema>;
+export type DependencyResetResult = z.infer<typeof DependencyResetResultSchema>;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -158,7 +158,9 @@ export type {
   BuildEnvironmentStatus,
   OnboardingState,
   DependencyInstallResult,
-} from "@/lib/schemas"
+  DependencyResetItem,
+  DependencyResetResult,
+} from "@/lib/schemas";
 
 export type PluginFilter = "ALL" | "INSTRUMENTS" | "EFFECTS" | "UTILITIES";
 

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,85 +1,122 @@
-import { useState, useEffect, useCallback } from "react"
-import { toast } from "sonner"
-import { open } from "@tauri-apps/plugin-dialog"
-import { useAppStore } from "@/stores/app-store"
-import { useBuildStore } from "@/stores/build-store"
-import { useSettingsStore } from "@/stores/settings-store"
-import { invalidateAndCheckDependencies, installDependency, launchClaudeAuth, launchCodexAuth } from "@/lib/commands"
-import { interpretDependencyInstallResult } from "@/lib/dependency-install"
-import { cn } from "@/lib/utils"
-import { AgentIcon } from "@/components/app/agent-icon"
-import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import { Label } from "@/components/ui/label"
-import { Input } from "@/components/ui/input"
-import { Separator } from "@/components/ui/separator"
-import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "@/components/ui/card"
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select"
-import type { DependencyStatus } from "@/lib/types"
-import { Download, FolderOpen, Loader2, RefreshCw, RotateCcw } from "lucide-react"
+import { useState, useEffect, useCallback } from "react";
+import { toast } from "sonner";
+import { open } from "@tauri-apps/plugin-dialog";
+import { useAppStore } from "@/stores/app-store";
+import { useBuildStore } from "@/stores/build-store";
+import { useSettingsStore } from "@/stores/settings-store";
+import {
+  invalidateAndCheckDependencies,
+  installDependency,
+  launchClaudeAuth,
+  launchCodexAuth,
+  resetDebugDependencies,
+} from "@/lib/commands";
+import { interpretDependencyInstallResult } from "@/lib/dependency-install";
+import { cn } from "@/lib/utils";
+import { AgentIcon } from "@/components/app/agent-icon";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardFooter,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import type { DependencyStatus } from "@/lib/types";
+import {
+  Download,
+  FolderOpen,
+  Loader2,
+  RefreshCw,
+  RotateCcw,
+  Trash2,
+} from "lucide-react";
 
 function formatDateTime(value?: string | null) {
-  if (!value) return "Never"
+  if (!value) return "Never";
 
   try {
     return new Intl.DateTimeFormat(undefined, {
       dateStyle: "medium",
       timeStyle: "short",
-    }).format(new Date(value))
+    }).format(new Date(value));
   } catch {
-    return value
+    return value;
   }
 }
 
 function formatBytes(value: number) {
-  if (value < 1024) return `${value} B`
+  if (value < 1024) return `${value} B`;
 
-  const units = ["KB", "MB", "GB"]
-  let size = value / 1024
-  let unitIndex = 0
+  const units = ["KB", "MB", "GB"];
+  let size = value / 1024;
+  let unitIndex = 0;
 
   while (size >= 1024 && unitIndex < units.length - 1) {
-    size /= 1024
-    unitIndex += 1
+    size /= 1024;
+    unitIndex += 1;
   }
 
-  return `${size.toFixed(size >= 10 ? 0 : 1)} ${units[unitIndex]}`
+  return `${size.toFixed(size >= 10 ? 0 : 1)} ${units[unitIndex]}`;
 }
 
-function getUpdateBadgeVariant(status: ReturnType<typeof useSettingsStore.getState>["updateStatus"]) {
+function getUpdateBadgeVariant(
+  status: ReturnType<typeof useSettingsStore.getState>["updateStatus"],
+) {
   switch (status) {
     case "available":
-      return "default"
+      return "default";
     case "checking":
     case "downloading":
     case "installing":
-      return "secondary"
+      return "secondary";
     case "error":
-      return "destructive"
+      return "destructive";
     case "not-available":
-      return "outline"
+      return "outline";
     default:
-      return "ghost"
+      return "ghost";
   }
 }
 
-function getUpdateStatusLabel(status: ReturnType<typeof useSettingsStore.getState>["updateStatus"]) {
+function getUpdateStatusLabel(
+  status: ReturnType<typeof useSettingsStore.getState>["updateStatus"],
+) {
   switch (status) {
     case "checking":
-      return "Checking"
+      return "Checking";
     case "available":
-      return "Update available"
+      return "Update available";
     case "not-available":
-      return "Up to date"
+      return "Up to date";
     case "downloading":
-      return "Downloading"
+      return "Downloading";
     case "installing":
-      return "Installing"
+      return "Installing";
     case "error":
-      return "Update error"
+      return "Update error";
     default:
-      return "Idle"
+      return "Idle";
   }
 }
 
@@ -88,7 +125,9 @@ export default function Settings() {
     <div className="h-full overflow-y-auto">
       <div className="w-full py-8 px-6">
         <div className="mb-6">
-          <h2 className="text-lg font-[ArchitypeStedelijk] uppercase tracking-[1px]">Settings</h2>
+          <h2 className="text-lg font-[ArchitypeStedelijk] uppercase tracking-[1px]">
+            Settings
+          </h2>
         </div>
 
         <Tabs defaultValue="general">
@@ -100,15 +139,23 @@ export default function Settings() {
           </TabsList>
 
           <div className="mt-4 flex-1 overflow-y-auto">
-            <TabsContent value="general"><GeneralTab /></TabsContent>
-            <TabsContent value="models"><ModelsTab /></TabsContent>
-            <TabsContent value="dependencies"><DependenciesTab /></TabsContent>
-            <TabsContent value="account"><AccountTab /></TabsContent>
+            <TabsContent value="general">
+              <GeneralTab />
+            </TabsContent>
+            <TabsContent value="models">
+              <ModelsTab />
+            </TabsContent>
+            <TabsContent value="dependencies">
+              <DependenciesTab />
+            </TabsContent>
+            <TabsContent value="account">
+              <AccountTab />
+            </TabsContent>
           </div>
         </Tabs>
       </div>
     </div>
-  )
+  );
 }
 
 function GeneralTab() {
@@ -128,37 +175,45 @@ function GeneralTab() {
     checkForAppUpdate,
     installAppUpdate,
     clearUpdateError,
-  } = useSettingsStore()
-  const isBuildRunning = useBuildStore((s) => s.isRunning)
-  const supportsAu = installPaths?.supportedFormats.includes("AU") ?? false
-  const supportsVst3 = installPaths?.supportedFormats.includes("VST3") ?? false
-  const isCheckingForUpdates = updateStatus === "checking"
-  const isInstallingUpdate = updateStatus === "downloading" || updateStatus === "installing"
+  } = useSettingsStore();
+  const isBuildRunning = useBuildStore((s) => s.isRunning);
+  const supportsAu = installPaths?.supportedFormats.includes("AU") ?? false;
+  const supportsVst3 = installPaths?.supportedFormats.includes("VST3") ?? false;
+  const isCheckingForUpdates = updateStatus === "checking";
+  const isInstallingUpdate =
+    updateStatus === "downloading" || updateStatus === "installing";
 
-  useEffect(() => { loadInstallPaths() }, [loadInstallPaths])
-  useEffect(() => { void loadAppVersion() }, [loadAppVersion])
+  useEffect(() => {
+    loadInstallPaths();
+  }, [loadInstallPaths]);
+  useEffect(() => {
+    void loadAppVersion();
+  }, [loadAppVersion]);
 
   const chooseFolder = async (format: string) => {
-    const selection = await open({ directory: true, multiple: false })
-    if (typeof selection !== "string") return
-    await useSettingsStore.getState().setInstallPath(format, selection)
-  }
+    const selection = await open({ directory: true, multiple: false });
+    if (typeof selection !== "string") return;
+    await useSettingsStore.getState().setInstallPath(format, selection);
+  };
 
   const handleCheckForUpdates = async () => {
-    clearUpdateError()
-    await checkForAppUpdate(true)
-  }
+    clearUpdateError();
+    await checkForAppUpdate(true);
+  };
 
   const handleInstallUpdate = async () => {
-    clearUpdateError()
-    await installAppUpdate()
-  }
+    clearUpdateError();
+    await installAppUpdate();
+  };
 
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-2">
         <Label className="text-[10px]">Appearance</Label>
-        <Select value={appearance} onValueChange={(v) => v && setAppearance(v as typeof appearance)}>
+        <Select
+          value={appearance}
+          onValueChange={(v) => v && setAppearance(v as typeof appearance)}
+        >
           <SelectTrigger className="w-full">
             <SelectValue />
           </SelectTrigger>
@@ -181,18 +236,28 @@ function GeneralTab() {
         <div className="flex flex-col gap-2">
           {supportsAu && (
             <div className="flex flex-col gap-1">
-              <span className="text-[10px] text-muted-foreground/50">AU Components</span>
+              <span className="text-[10px] text-muted-foreground/50">
+                AU Components
+              </span>
               <div className="flex items-center gap-1.5">
                 <Input
                   readOnly
                   value={installPaths?.auPath ?? ""}
                   className="flex-1 cursor-default text-[10px]"
                 />
-                <Button variant="outline" size="xs" onClick={() => chooseFolder("AU")}>
+                <Button
+                  variant="outline"
+                  size="xs"
+                  onClick={() => chooseFolder("AU")}
+                >
                   <FolderOpen className="size-3" />
                 </Button>
                 {installPaths && !installPaths.auIsDefault && (
-                  <Button variant="ghost" size="xs" onClick={() => resetInstallPath("AU")}>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    onClick={() => resetInstallPath("AU")}
+                  >
                     <RotateCcw className="size-3" />
                   </Button>
                 )}
@@ -202,18 +267,28 @@ function GeneralTab() {
 
           {supportsVst3 && (
             <div className="flex flex-col gap-1">
-              <span className="text-[10px] text-muted-foreground/50">VST3 Plugins</span>
+              <span className="text-[10px] text-muted-foreground/50">
+                VST3 Plugins
+              </span>
               <div className="flex items-center gap-1.5">
                 <Input
                   readOnly
                   value={installPaths?.vst3Path ?? ""}
                   className="flex-1 cursor-default text-[10px]"
                 />
-                <Button variant="outline" size="xs" onClick={() => chooseFolder("VST3")}>
+                <Button
+                  variant="outline"
+                  size="xs"
+                  onClick={() => chooseFolder("VST3")}
+                >
                   <FolderOpen className="size-3" />
                 </Button>
                 {installPaths && !installPaths.vst3IsDefault && (
-                  <Button variant="ghost" size="xs" onClick={() => resetInstallPath("VST3")}>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    onClick={() => resetInstallPath("VST3")}
+                  >
                     <RotateCcw className="size-3" />
                   </Button>
                 )}
@@ -256,7 +331,9 @@ function GeneralTab() {
             {availableUpdate ? (
               <div className="min-w-0">
                 <div className="flex items-center justify-between gap-3">
-                  <div className="text-xs">Version {availableUpdate.version}</div>
+                  <div className="text-xs">
+                    Version {availableUpdate.version}
+                  </div>
                   <div className="text-[10px] text-muted-foreground/60 shrink-0">
                     {formatDateTime(availableUpdate.date)}
                   </div>
@@ -278,7 +355,9 @@ function GeneralTab() {
             {downloadProgress && (
               <div className="text-[10px] text-muted-foreground/60">
                 Downloaded {formatBytes(downloadProgress.downloaded)}
-                {downloadProgress.total ? ` of ${formatBytes(downloadProgress.total)}` : ""}
+                {downloadProgress.total
+                  ? ` of ${formatBytes(downloadProgress.total)}`
+                  : ""}
               </div>
             )}
 
@@ -323,58 +402,74 @@ function GeneralTab() {
         </Card>
       </div>
     </div>
-  )
+  );
 }
 
 function ModelsTab() {
-  const { modelCatalog, loadCatalog, refreshModels, isRefreshing } = useSettingsStore()
-  const [installingCli, setInstallingCli] = useState<string | null>(null)
-  useEffect(() => { loadCatalog() }, [loadCatalog])
+  const { modelCatalog, loadCatalog, refreshModels, isRefreshing } =
+    useSettingsStore();
+  const [installingCli, setInstallingCli] = useState<string | null>(null);
+  useEffect(() => {
+    loadCatalog();
+  }, [loadCatalog]);
 
-  const hasClaudeCode = modelCatalog.some((p) => p.name.toLowerCase().includes("claude"))
-  const hasCodex = modelCatalog.some((p) => p.name.toLowerCase().includes("codex"))
+  const hasClaudeCode = modelCatalog.some((p) =>
+    p.name.toLowerCase().includes("claude"),
+  );
+  const hasCodex = modelCatalog.some((p) =>
+    p.name.toLowerCase().includes("codex"),
+  );
 
-  const handleInstallCli = useCallback(async (key: string) => {
-    const label = key === "claude_code" ? "Claude Code" : "Codex"
-    setInstallingCli(key)
-    try {
-      const result = await installDependency(key)
-      const outcome = interpretDependencyInstallResult(result)
+  const handleInstallCli = useCallback(
+    async (key: string) => {
+      const label = key === "claude_code" ? "Claude Code" : "Codex";
+      setInstallingCli(key);
+      try {
+        const result = await installDependency(key);
+        const outcome = interpretDependencyInstallResult(result);
 
-      if (outcome.shouldRefreshProviderState) {
-        await invalidateAndCheckDependencies()
-        await refreshModels()
+        if (outcome.shouldRefreshProviderState) {
+          await invalidateAndCheckDependencies();
+          await refreshModels();
+        }
+
+        if (outcome.state === "verified") {
+          toast.success(label + " installed successfully");
+        } else if (outcome.state === "auth_required") {
+          toast.info(outcome.message, { description: "Opening browser…" });
+          if (key === "codex") await launchCodexAuth();
+          else await launchClaudeAuth();
+        } else if (outcome.state === "failed") {
+          toast.error(`Failed to install ${label}`, {
+            description: outcome.message,
+          });
+        } else {
+          toast.success(outcome.message);
+        }
+      } catch (e) {
+        toast.error(`Failed to install ${label}`, { description: String(e) });
       }
-
-      if (outcome.state === "verified") {
-        toast.success(label + " installed successfully")
-      } else if (outcome.state === "auth_required") {
-        toast.info(outcome.message, { description: "Opening browser…" })
-        if (key === "codex") await launchCodexAuth()
-        else await launchClaudeAuth()
-      } else if (outcome.state === "failed") {
-        toast.error(`Failed to install ${label}`, { description: outcome.message })
-      } else {
-        toast.success(outcome.message)
-      }
-    } catch (e) {
-      toast.error(`Failed to install ${label}`, { description: String(e) })
-    }
-    setInstallingCli(null)
-  }, [refreshModels])
+      setInstallingCli(null);
+    },
+    [refreshModels],
+  );
 
   return (
     <div className="flex flex-col gap-4">
       {modelCatalog.length === 0 && !isRefreshing && (
         <p className="text-[10px] text-muted-foreground/50">
-          No AI providers detected. Install Claude Code or Codex CLI from the Dependencies tab.
+          No AI providers detected. Install Claude Code or Codex CLI from the
+          Dependencies tab.
         </p>
       )}
 
       {modelCatalog.map((provider) => (
         <div key={provider.id} className="flex flex-col gap-2">
           <div className="flex items-center gap-1.5">
-            <AgentIcon agent={provider.name} className="size-3 text-muted-foreground/60" />
+            <AgentIcon
+              agent={provider.name}
+              className="size-3 text-muted-foreground/60"
+            />
             <Label className="text-[10px]">{provider.name}</Label>
           </div>
           <Card size="sm">
@@ -385,10 +480,16 @@ function ModelsTab() {
                   <div className="flex items-center gap-3 py-2">
                     <div className="flex-1 min-w-0">
                       <div className="text-xs">{model.name}</div>
-                      <div className="text-[10px] text-muted-foreground/60">{model.subtitle}</div>
+                      <div className="text-[10px] text-muted-foreground/60">
+                        {model.subtitle}
+                      </div>
                     </div>
-                    {model.default && <Badge variant="secondary">Default</Badge>}
-                    <span className="text-[10px] text-muted-foreground/40">{model.flag}</span>
+                    {model.default && (
+                      <Badge variant="secondary">Default</Badge>
+                    )}
+                    <span className="text-[10px] text-muted-foreground/40">
+                      {model.flag}
+                    </span>
                   </div>
                 </div>
               ))}
@@ -399,130 +500,221 @@ function ModelsTab() {
 
       {!hasClaudeCode && (
         <div className="flex items-center gap-2 px-1 py-2">
-          <AgentIcon agent="Claude Code" className="size-3 text-muted-foreground/40" />
-          <span className="text-[10px] text-muted-foreground/50 flex-1">Claude Code CLI not installed</span>
-          <Button variant="outline" size="xs" disabled={installingCli !== null} onClick={() => handleInstallCli("claude_code")}>
+          <AgentIcon
+            agent="Claude Code"
+            className="size-3 text-muted-foreground/40"
+          />
+          <span className="text-[10px] text-muted-foreground/50 flex-1">
+            Claude Code CLI not installed
+          </span>
+          <Button
+            variant="outline"
+            size="xs"
+            disabled={installingCli !== null}
+            onClick={() => handleInstallCli("claude_code")}
+          >
             {installingCli === "claude_code" ? (
-              <><div className="size-3 border-[1.5px] border-current border-t-transparent rounded-full animate-spin mr-1.5" />Installing…</>
-            ) : "Install"}
+              <>
+                <div className="size-3 border-[1.5px] border-current border-t-transparent rounded-full animate-spin mr-1.5" />
+                Installing…
+              </>
+            ) : (
+              "Install"
+            )}
           </Button>
         </div>
       )}
 
       {!hasCodex && (
         <div className="flex items-center gap-2 px-1 py-2">
-          <AgentIcon agent="Codex" className="size-3 text-muted-foreground/40" />
-          <span className="text-[10px] text-muted-foreground/50 flex-1">Codex CLI not installed</span>
-          <Button variant="outline" size="xs" disabled={installingCli !== null} onClick={() => handleInstallCli("codex")}>
+          <AgentIcon
+            agent="Codex"
+            className="size-3 text-muted-foreground/40"
+          />
+          <span className="text-[10px] text-muted-foreground/50 flex-1">
+            Codex CLI not installed
+          </span>
+          <Button
+            variant="outline"
+            size="xs"
+            disabled={installingCli !== null}
+            onClick={() => handleInstallCli("codex")}
+          >
             {installingCli === "codex" ? (
-              <><div className="size-3 border-[1.5px] border-current border-t-transparent rounded-full animate-spin mr-1.5" />Installing…</>
-            ) : "Install"}
+              <>
+                <div className="size-3 border-[1.5px] border-current border-t-transparent rounded-full animate-spin mr-1.5" />
+                Installing…
+              </>
+            ) : (
+              "Install"
+            )}
           </Button>
         </div>
       )}
-      <Button variant="outline" size="xs" onClick={refreshModels} disabled={isRefreshing} className="self-start">
+      <Button
+        variant="outline"
+        size="xs"
+        onClick={refreshModels}
+        disabled={isRefreshing}
+        className="self-start"
+      >
         {isRefreshing ? "Refreshing..." : "Refresh Models"}
       </Button>
     </div>
-  )
+  );
 }
 
 const DEP_INSTALL_KEY: Record<string, string> = {
   "Xcode Command Line Tools": "xcode_clt",
-  "CMake": "cmake",
+  CMake: "cmake",
   "Claude Code CLI": "claude_code",
   "Codex CLI": "codex",
-}
+};
 
-const AI_PROVIDER_NAMES = new Set(["Claude Code CLI", "Codex CLI"])
+const AI_PROVIDER_NAMES = new Set(["Claude Code CLI", "Codex CLI"]);
 
 function DependenciesTab() {
-  const [deps, setDeps] = useState<DependencyStatus[]>([])
-  const [installing, setInstalling] = useState<string | null>(null)
-  const buildEnvironment = useSettingsStore((s) => s.buildEnvironment)
-  const loadBuildEnvironment = useSettingsStore((s) => s.loadBuildEnvironment)
-  const installManagedJuce = useSettingsStore((s) => s.installManagedJuce)
-  const setJuceOverride = useSettingsStore((s) => s.setJuceOverride)
-  const clearJuceOverride = useSettingsStore((s) => s.clearJuceOverride)
-  const isPreparingEnvironment = useSettingsStore((s) => s.isPreparingEnvironment)
-  const isLoadingBuildEnvironment = useSettingsStore((s) => s.isLoadingBuildEnvironment)
+  const [deps, setDeps] = useState<DependencyStatus[]>([]);
+  const [installing, setInstalling] = useState<string | null>(null);
+  const [isResetDialogOpen, setIsResetDialogOpen] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
+  const buildEnvironment = useSettingsStore((s) => s.buildEnvironment);
+  const loadBuildEnvironment = useSettingsStore((s) => s.loadBuildEnvironment);
+  const installManagedJuce = useSettingsStore((s) => s.installManagedJuce);
+  const setJuceOverride = useSettingsStore((s) => s.setJuceOverride);
+  const clearJuceOverride = useSettingsStore((s) => s.clearJuceOverride);
+  const refreshModels = useSettingsStore((s) => s.refreshModels);
+  const isPreparingEnvironment = useSettingsStore(
+    (s) => s.isPreparingEnvironment,
+  );
+  const isLoadingBuildEnvironment = useSettingsStore(
+    (s) => s.isLoadingBuildEnvironment,
+  );
 
   const refreshDeps = useCallback(async () => {
     try {
-      const next = await invalidateAndCheckDependencies()
-      setDeps(next)
+      const next = await invalidateAndCheckDependencies();
+      setDeps(next);
     } catch {
-      setDeps([])
+      setDeps([]);
     }
-  }, [])
+  }, []);
 
   useEffect(() => {
-    void refreshDeps()
-    void loadBuildEnvironment()
-  }, [refreshDeps, loadBuildEnvironment])
+    void refreshDeps();
+    void loadBuildEnvironment();
+  }, [refreshDeps, loadBuildEnvironment]);
 
-  const handleInstall = useCallback(async (dep: DependencyStatus) => {
-    const key = DEP_INSTALL_KEY[dep.name]
-    if (!key) return
-    setInstalling(key)
-    try {
-      const result = await installDependency(key)
-      const outcome = interpretDependencyInstallResult(result)
+  const handleInstall = useCallback(
+    async (dep: DependencyStatus) => {
+      const key = DEP_INSTALL_KEY[dep.name];
+      if (!key) return;
+      setInstalling(key);
+      try {
+        const result = await installDependency(key);
+        const outcome = interpretDependencyInstallResult(result);
 
-      if (outcome.state === "verified") {
-        toast.success(`${dep.name} installed successfully`)
-      } else if (outcome.state === "auth_required") {
-        toast.info(outcome.message, { description: "Opening browser…" })
-        if (dep.name === "Codex CLI") await launchCodexAuth()
-        else if (dep.name === "Claude Code CLI") await launchClaudeAuth()
-      } else if (outcome.state === "pending") {
-        toast.success(outcome.message)
-      } else {
-        toast.error(`Failed to install ${dep.name}`, { description: outcome.message })
+        if (outcome.state === "verified") {
+          toast.success(`${dep.name} installed successfully`);
+        } else if (outcome.state === "auth_required") {
+          toast.info(outcome.message, { description: "Opening browser…" });
+          if (dep.name === "Codex CLI") await launchCodexAuth();
+          else if (dep.name === "Claude Code CLI") await launchClaudeAuth();
+        } else if (outcome.state === "pending") {
+          toast.success(outcome.message);
+        } else {
+          toast.error(`Failed to install ${dep.name}`, {
+            description: outcome.message,
+          });
+        }
+      } catch (e) {
+        toast.error(`Failed to install ${dep.name}`, {
+          description: String(e),
+        });
       }
-    } catch (e) {
-      toast.error(`Failed to install ${dep.name}`, { description: String(e) })
-    }
-    await refreshDeps()
-    setInstalling(null)
-  }, [refreshDeps])
+      await refreshDeps();
+      setInstalling(null);
+    },
+    [refreshDeps],
+  );
 
   const handleAuth = useCallback(async (depName: string) => {
     try {
-      if (depName === "Codex CLI") await launchCodexAuth()
-      else await launchClaudeAuth()
+      if (depName === "Codex CLI") await launchCodexAuth();
+      else await launchClaudeAuth();
     } catch {}
-  }, [])
+  }, []);
 
   const chooseJuceFolder = useCallback(async () => {
-    const selection = await open({ directory: true, multiple: false })
-    if (typeof selection !== "string") return
-    await setJuceOverride(selection)
-    await refreshDeps()
-  }, [refreshDeps, setJuceOverride])
+    const selection = await open({ directory: true, multiple: false });
+    if (typeof selection !== "string") return;
+    await setJuceOverride(selection);
+    await refreshDeps();
+  }, [refreshDeps, setJuceOverride]);
 
   const installManagedCopy = useCallback(async () => {
-    await installManagedJuce()
-    await refreshDeps()
-  }, [installManagedJuce, refreshDeps])
+    await installManagedJuce();
+    await refreshDeps();
+  }, [installManagedJuce, refreshDeps]);
 
   const restoreManagedCopy = useCallback(async () => {
-    await clearJuceOverride()
-    await refreshDeps()
-  }, [clearJuceOverride, refreshDeps])
+    await clearJuceOverride();
+    await refreshDeps();
+  }, [clearJuceOverride, refreshDeps]);
 
   const recheckEnvironment = useCallback(async () => {
-    await Promise.all([refreshDeps(), loadBuildEnvironment()])
-  }, [loadBuildEnvironment, refreshDeps])
+    await Promise.all([refreshDeps(), loadBuildEnvironment()]);
+  }, [loadBuildEnvironment, refreshDeps]);
+
+  const handleResetDependencies = useCallback(async () => {
+    setIsResetting(true);
+    try {
+      const result = await resetDebugDependencies();
+      await Promise.all([
+        refreshDeps(),
+        loadBuildEnvironment(),
+        refreshModels(),
+      ]);
+
+      const failures = result.items.filter((item) => item.status === "failed");
+      const skipped = result.items.filter((item) => item.status === "skipped");
+
+      if (failures.length > 0) {
+        toast.error(result.summary, {
+          description: failures
+            .map((item) => `${item.name}: ${item.detail}`)
+            .join(" "),
+        });
+      } else if (skipped.length > 0) {
+        toast.success(result.summary, {
+          description: skipped
+            .map((item) => `${item.name}: ${item.detail}`)
+            .join(" "),
+        });
+      } else {
+        toast.success(result.summary);
+      }
+
+      setIsResetDialogOpen(false);
+    } catch (e) {
+      toast.error("Failed to reset dependencies", { description: String(e) });
+    } finally {
+      setIsResetting(false);
+    }
+  }, [loadBuildEnvironment, refreshDeps, refreshModels]);
 
   // Filter out JUCE (handled by Build Environment card) and split into groups
-  const filteredDeps = deps.filter(d => d.name !== "JUCE SDK")
-  const buildToolDeps = filteredDeps.filter(d => !AI_PROVIDER_NAMES.has(d.name))
-  const providerDeps = filteredDeps.filter(d => AI_PROVIDER_NAMES.has(d.name))
+  const filteredDeps = deps.filter((d) => d.name !== "JUCE SDK");
+  const buildToolDeps = filteredDeps.filter(
+    (d) => !AI_PROVIDER_NAMES.has(d.name),
+  );
+  const providerDeps = filteredDeps.filter((d) =>
+    AI_PROVIDER_NAMES.has(d.name),
+  );
 
   const renderDepRow = (dep: DependencyStatus, i: number) => {
-    const key = DEP_INSTALL_KEY[dep.name]
-    const isProvider = AI_PROVIDER_NAMES.has(dep.name)
+    const key = DEP_INSTALL_KEY[dep.name];
+    const isProvider = AI_PROVIDER_NAMES.has(dep.name);
     return (
       <div key={dep.name}>
         {i > 0 && <Separator />}
@@ -530,17 +722,35 @@ function DependenciesTab() {
           {installing === key ? (
             <Loader2 className="size-3 shrink-0 text-muted-foreground/60 animate-spin" />
           ) : (
-            <span className={cn("size-1.5 rounded-full shrink-0", dep.installed && !dep.authRequired ? "bg-green-400" : dep.authRequired ? "bg-amber-400" : "bg-destructive")} />
+            <span
+              className={cn(
+                "size-1.5 rounded-full shrink-0",
+                dep.installed && !dep.authRequired
+                  ? "bg-green-400"
+                  : dep.authRequired
+                    ? "bg-amber-400"
+                    : "bg-destructive",
+              )}
+            />
           )}
           <div className="flex-1 min-w-0">
             <div className="text-xs">{dep.name}</div>
-            {dep.detail && <div className="text-[10px] text-muted-foreground/60 truncate">{dep.detail}</div>}
+            {dep.detail && (
+              <div className="text-[10px] text-muted-foreground/60 truncate">
+                {dep.detail}
+              </div>
+            )}
           </div>
           {dep.installed && !dep.authRequired && (
             <span className="text-[9px] shrink-0 text-success">Installed</span>
           )}
           {dep.installed && dep.authRequired && (
-            <Button variant="outline" size="xs" onClick={() => handleAuth(dep.name)} disabled={installing !== null}>
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={() => handleAuth(dep.name)}
+              disabled={installing !== null}
+            >
               Sign in
             </Button>
           )}
@@ -551,19 +761,26 @@ function DependenciesTab() {
               disabled={installing !== null}
               onClick={() => handleInstall(dep)}
             >
-              {installing === key && <Loader2 className="size-3 animate-spin" />}
+              {installing === key && (
+                <Loader2 className="size-3 animate-spin" />
+              )}
               {installing === key ? "Installing…" : "Install"}
             </Button>
           )}
           {!dep.installed && !key && (
-            <span className={cn("text-[9px] shrink-0", isProvider ? "text-muted-foreground/40" : "text-destructive")}>
+            <span
+              className={cn(
+                "text-[9px] shrink-0",
+                isProvider ? "text-muted-foreground/40" : "text-destructive",
+              )}
+            >
               {isProvider ? "Optional" : "Missing"}
             </span>
           )}
         </div>
       </div>
-    )
-  }
+    );
+  };
 
   return (
     <div className="flex flex-col gap-4">
@@ -580,27 +797,59 @@ function DependenciesTab() {
                     : "Not configured"}
                 </div>
               </div>
-              <span className={cn("text-[10px]", buildEnvironment?.state === "ready" ? "text-success" : "text-destructive")}>
-                {isLoadingBuildEnvironment ? "Checking..." : buildEnvironment?.state === "ready" ? "Ready" : "Blocked"}
+              <span
+                className={cn(
+                  "text-[10px]",
+                  buildEnvironment?.state === "ready"
+                    ? "text-success"
+                    : "text-destructive",
+                )}
+              >
+                {isLoadingBuildEnvironment
+                  ? "Checking..."
+                  : buildEnvironment?.state === "ready"
+                    ? "Ready"
+                    : "Blocked"}
               </span>
             </div>
 
             {buildEnvironment?.issues.length ? (
               <div className="flex flex-col gap-1.5">
                 {buildEnvironment.issues.map((issue) => (
-                  <div key={issue.code} className="bg-muted/40 rounded-md px-2.5 py-2">
+                  <div
+                    key={issue.code}
+                    className="bg-muted/40 rounded-md px-2.5 py-2"
+                  >
                     <div className="text-xs">{issue.title}</div>
-                    <div className="text-[10px] text-muted-foreground/60 mt-0.5">{issue.detail}</div>
+                    <div className="text-[10px] text-muted-foreground/60 mt-0.5">
+                      {issue.detail}
+                    </div>
                   </div>
                 ))}
                 <div className="flex flex-wrap gap-1.5">
-                  <Button variant="outline" size="xs" onClick={recheckEnvironment} disabled={isPreparingEnvironment}>
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    onClick={recheckEnvironment}
+                    disabled={isPreparingEnvironment}
+                  >
                     Re-check
                   </Button>
-                  <Button size="xs" onClick={installManagedCopy} disabled={isPreparingEnvironment}>
-                    {isPreparingEnvironment ? "Preparing..." : "Install Managed JUCE"}
+                  <Button
+                    size="xs"
+                    onClick={installManagedCopy}
+                    disabled={isPreparingEnvironment}
+                  >
+                    {isPreparingEnvironment
+                      ? "Preparing..."
+                      : "Install Managed JUCE"}
                   </Button>
-                  <Button variant="secondary" size="xs" onClick={chooseJuceFolder} disabled={isPreparingEnvironment}>
+                  <Button
+                    variant="secondary"
+                    size="xs"
+                    onClick={chooseJuceFolder}
+                    disabled={isPreparingEnvironment}
+                  >
                     Choose JUCE Folder
                   </Button>
                 </div>
@@ -608,12 +857,20 @@ function DependenciesTab() {
             ) : (
               <div className="text-[10px] text-muted-foreground/60">
                 {buildEnvironment?.jucePath && (
-                  <span className="text-muted-foreground/40 break-all">{buildEnvironment.jucePath}</span>
+                  <span className="text-muted-foreground/40 break-all">
+                    {buildEnvironment.jucePath}
+                  </span>
                 )}
               </div>
             )}
             {buildEnvironment?.juceSource === "override" && (
-              <Button variant="ghost" size="xs" onClick={restoreManagedCopy} disabled={isPreparingEnvironment} className="self-start">
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={restoreManagedCopy}
+                disabled={isPreparingEnvironment}
+                className="self-start"
+              >
                 Use Managed Copy
               </Button>
             )}
@@ -643,28 +900,106 @@ function DependenciesTab() {
         </div>
       )}
 
-      <Button variant="outline" size="xs" onClick={refreshDeps} disabled={installing !== null} className="self-start">
+      <Button
+        variant="outline"
+        size="xs"
+        onClick={refreshDeps}
+        disabled={installing !== null}
+        className="self-start"
+      >
         <RefreshCw className="size-3" />
         Re-check dependencies
       </Button>
+
+      <div className="flex items-center justify-between gap-3 rounded-lg border border-dashed border-border/60 bg-muted/20 px-3 py-2">
+        <div className="min-w-0">
+          <div className="text-[9px] uppercase tracking-[0.18em] text-muted-foreground/35">
+            Debug
+          </div>
+          <p className="text-[10px] text-muted-foreground/55">
+            Reset removable dependency installs to replay onboarding and setup
+            flows.
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="xs"
+          disabled={
+            installing !== null || isPreparingEnvironment || isResetting
+          }
+          onClick={() => setIsResetDialogOpen(true)}
+          className="shrink-0 text-muted-foreground/55 hover:text-destructive"
+        >
+          <Trash2 className="size-3" />
+          Reset installs
+        </Button>
+      </div>
+
+      <Dialog open={isResetDialogOpen} onOpenChange={setIsResetDialogOpen}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>Reset dependency installs?</DialogTitle>
+            <DialogDescription>
+              This removes Foundry-managed installs it can safely reset: Claude
+              Code CLI, Codex CLI, managed JUCE, and Homebrew CMake when
+              applicable. System toolchains like Xcode Command Line Tools stay
+              in place.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              size="xs"
+              disabled={isResetting}
+              onClick={() => setIsResetDialogOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="xs"
+              disabled={isResetting}
+              onClick={() => void handleResetDependencies()}
+            >
+              {isResetting ? (
+                <>
+                  <Loader2 className="size-3 animate-spin" />
+                  Resetting…
+                </>
+              ) : (
+                <>
+                  <Trash2 className="size-3" />
+                  Reset installs
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
-  )
+  );
 }
 
 function AccountTab() {
-  const signOut = useAppStore((s) => s.signOut)
-  const userProfile = useAppStore((s) => s.userProfile)
+  const signOut = useAppStore((s) => s.signOut);
+  const userProfile = useAppStore((s) => s.userProfile);
 
   return (
     <div className="flex flex-col gap-3">
       {userProfile && (
         <p className="text-xs text-muted-foreground">
-          Signed in as {userProfile.email || userProfile.displayName || userProfile.id}
+          Signed in as{" "}
+          {userProfile.email || userProfile.displayName || userProfile.id}
         </p>
       )}
-      <Button variant="outline" size="xs" onClick={signOut} className="self-start text-destructive">
+      <Button
+        variant="outline"
+        size="xs"
+        onClick={signOut}
+        className="self-start text-destructive"
+      >
         Sign Out
       </Button>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- add a discreet debug reset action in Settings > Dependencies with confirmation
- add a Tauri reset command to remove removable managed installs and preserve system toolchains
- refresh dependency, model, and build-environment state after reset

## Verification
- npm run typecheck
- cargo test --manifest-path src-tauri/Cargo.toml
- npx -y react-doctor@latest . --verbose --diff