### PR TITLE
fix: enable fresh-mac onboarding without Homebrew/sudo

### DIFF
--- a/src-tauri/src/platform/macos.rs
+++ b/src-tauri/src/platform/macos.rs
@@ -95,8 +95,25 @@ fn path_from_cached_env(cmd: &str) -> Option<String> {
 }
 
 /// Resolve a command path using the cached login shell environment.
+/// Falls back to managed tool installations for cmake, npm, and node.
 pub fn resolve_command(cmd: &str) -> String {
-    path_from_cached_env(cmd).unwrap_or_else(|| cmd.to_string())
+    if let Some(resolved) = path_from_cached_env(cmd) {
+        if resolved != cmd {
+            return resolved;
+        }
+    }
+
+    let managed = match cmd {
+        "cmake" => foundry_paths::managed_cmake_binary(),
+        "npm" => foundry_paths::managed_npm_binary(),
+        "node" => foundry_paths::managed_node_binary(),
+        _ => return cmd.to_string(),
+    };
+    if managed.is_file() {
+        return managed.to_string_lossy().to_string();
+    }
+
+    cmd.to_string()
 }
 
 fn resolve_known_cli(cmd: &str) -> Option<String> {

--- a/src-tauri/src/services/build_environment.rs
+++ b/src-tauri/src/services/build_environment.rs
@@ -275,8 +275,17 @@ async fn inspect_environment(
 }
 
 fn collect_dependency_issues() -> Vec<BuildEnvironmentIssue> {
-    platform::required_dependencies()
-        .into_iter()
+    let deps = platform::required_dependencies();
+
+    let has_claude = deps.iter().any(|spec| {
+        spec.name == "Claude Code CLI" && platform::check_dependency(spec).is_some()
+    });
+    let has_codex = deps.iter().any(|spec| {
+        spec.name == "Codex CLI" && platform::check_dependency(spec).is_some()
+    });
+    let has_any_agent = has_claude || has_codex;
+
+    deps.into_iter()
         .filter_map(|spec| {
             if platform::check_dependency(&spec).is_some() {
                 return None;
@@ -303,14 +312,17 @@ fn collect_dependency_issues() -> Vec<BuildEnvironmentIssue> {
                     "Ninja is required before Foundry can build JUCE projects.",
                     Some("Install Ninja"),
                 ),
-                "Claude Code CLI" => (
-                    "claude_cli_missing",
-                    "Claude Code CLI is required before Foundry can generate code.",
-                    Some("Install Claude CLI"),
-                ),
-                "Codex CLI" => {
-                    // Codex is optional — don't block the build environment
-                    return None;
+                "Claude Code CLI" | "Codex CLI" => {
+                    if has_any_agent {
+                        return None;
+                    }
+                    return Some(BuildEnvironmentIssue {
+                        code: "agent_cli_missing".into(),
+                        title: "AI engine not installed".into(),
+                        detail: "Install Claude Code or Codex CLI to generate plugins.".into(),
+                        recoverable: false,
+                        action_label: Some("Open Setup".into()),
+                    });
                 }
                 _ => (
                     "dependency_missing",

--- a/src-tauri/src/services/foundry_paths.rs
+++ b/src-tauri/src/services/foundry_paths.rs
@@ -2,7 +2,11 @@ use crate::models::plugin::PluginFormat;
 use std::path::PathBuf;
 
 pub const DEFAULT_MANAGED_JUCE_VERSION: &str = "8.0.12";
+
+#[cfg(target_os = "macos")]
 pub const MANAGED_CMAKE_VERSION: &str = "3.31.6";
+
+#[cfg(target_os = "macos")]
 pub const MANAGED_NODE_VERSION: &str = "22.14.0";
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
@@ -44,14 +48,17 @@ pub fn managed_juce_dir(version: &str) -> PathBuf {
     managed_juce_root_dir().join(version)
 }
 
+#[cfg(target_os = "macos")]
 pub fn managed_cmake_root_dir() -> PathBuf {
     application_support_dir().join("CMake")
 }
 
+#[cfg(target_os = "macos")]
 pub fn managed_cmake_dir() -> PathBuf {
     managed_cmake_root_dir().join(MANAGED_CMAKE_VERSION)
 }
 
+#[cfg(target_os = "macos")]
 pub fn managed_cmake_binary() -> PathBuf {
     managed_cmake_dir()
         .join(format!("cmake-{}-macos-universal", MANAGED_CMAKE_VERSION))
@@ -61,14 +68,17 @@ pub fn managed_cmake_binary() -> PathBuf {
         .join("cmake")
 }
 
+#[cfg(target_os = "macos")]
 pub fn managed_node_root_dir() -> PathBuf {
     application_support_dir().join("Node")
 }
 
+#[cfg(target_os = "macos")]
 pub fn managed_node_dir() -> PathBuf {
     managed_node_root_dir().join(MANAGED_NODE_VERSION)
 }
 
+#[cfg(target_os = "macos")]
 pub fn managed_node_binary() -> PathBuf {
     let arch = if std::env::consts::ARCH == "aarch64" {
         "arm64"
@@ -81,6 +91,7 @@ pub fn managed_node_binary() -> PathBuf {
         .join("node")
 }
 
+#[cfg(target_os = "macos")]
 pub fn managed_npm_binary() -> PathBuf {
     let arch = if std::env::consts::ARCH == "aarch64" {
         "arm64"

--- a/src-tauri/src/services/foundry_paths.rs
+++ b/src-tauri/src/services/foundry_paths.rs
@@ -2,6 +2,8 @@ use crate::models::plugin::PluginFormat;
 use std::path::PathBuf;
 
 pub const DEFAULT_MANAGED_JUCE_VERSION: &str = "8.0.12";
+pub const MANAGED_CMAKE_VERSION: &str = "3.31.6";
+pub const MANAGED_NODE_VERSION: &str = "22.14.0";
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -40,6 +42,55 @@ pub fn managed_juce_root_dir() -> PathBuf {
 
 pub fn managed_juce_dir(version: &str) -> PathBuf {
     managed_juce_root_dir().join(version)
+}
+
+pub fn managed_cmake_root_dir() -> PathBuf {
+    application_support_dir().join("CMake")
+}
+
+pub fn managed_cmake_dir() -> PathBuf {
+    managed_cmake_root_dir().join(MANAGED_CMAKE_VERSION)
+}
+
+pub fn managed_cmake_binary() -> PathBuf {
+    managed_cmake_dir()
+        .join(format!("cmake-{}-macos-universal", MANAGED_CMAKE_VERSION))
+        .join("CMake.app")
+        .join("Contents")
+        .join("bin")
+        .join("cmake")
+}
+
+pub fn managed_node_root_dir() -> PathBuf {
+    application_support_dir().join("Node")
+}
+
+pub fn managed_node_dir() -> PathBuf {
+    managed_node_root_dir().join(MANAGED_NODE_VERSION)
+}
+
+pub fn managed_node_binary() -> PathBuf {
+    let arch = if std::env::consts::ARCH == "aarch64" {
+        "arm64"
+    } else {
+        "x64"
+    };
+    managed_node_dir()
+        .join(format!("node-v{}-darwin-{}", MANAGED_NODE_VERSION, arch))
+        .join("bin")
+        .join("node")
+}
+
+pub fn managed_npm_binary() -> PathBuf {
+    let arch = if std::env::consts::ARCH == "aarch64" {
+        "arm64"
+    } else {
+        "x64"
+    };
+    managed_node_dir()
+        .join(format!("node-v{}-darwin-{}", MANAGED_NODE_VERSION, arch))
+        .join("bin")
+        .join("npm")
 }
 
 /// Read a custom install path override for the given plugin format.

--- a/src-tauri/src/services/onboarding.rs
+++ b/src-tauri/src/services/onboarding.rs
@@ -28,6 +28,142 @@ fn silent_command(cmd: &str) -> Command {
     c
 }
 
+#[cfg(target_os = "macos")]
+const CMAKE_DOWNLOAD_URL: &str = "https://github.com/Kitware/CMake/releases/download/v{version}/cmake-{version}-macos-universal.tar.gz";
+
+#[cfg(target_os = "macos")]
+const NODE_DOWNLOAD_URL: &str =
+    "https://nodejs.org/dist/v{version}/node-v{version}-darwin-{arch}.tar.gz";
+
+#[cfg(target_os = "macos")]
+fn macos_node_arch() -> &'static str {
+    if std::env::consts::ARCH == "aarch64" {
+        "arm64"
+    } else {
+        "x64"
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn download_file_sync(url: &str, dest: &Path) -> Result<(), String> {
+    let runtime = tokio::runtime::Handle::current();
+    let url = url.to_string();
+    let dest = dest.to_path_buf();
+    runtime.block_on(async {
+        let response = reqwest::get(&url)
+            .await
+            .map_err(|e| format!("Download failed: {}", e))?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "Download returned status {} for {}",
+                response.status(),
+                url
+            ));
+        }
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| format!("Download failed: {}", e))?;
+        std::fs::write(&dest, &bytes)
+            .map_err(|e| format!("Failed to write {}: {}", dest.display(), e))?;
+        Ok(())
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn extract_tarball(archive_path: &Path, extract_dir: &Path) -> Result<(), String> {
+    let output = Command::new("tar")
+        .args([
+            "-xzf",
+            &archive_path.to_string_lossy(),
+            "-C",
+            &extract_dir.to_string_lossy(),
+        ])
+        .output()
+        .map_err(|e| format!("Failed to run tar: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Extraction failed: {}", stderr.trim()));
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn install_managed_cmake() -> Result<PathBuf, String> {
+    let cmake_binary = foundry_paths::managed_cmake_binary();
+    if cmake_binary.is_file() {
+        info!("Managed CMake already installed at {}", cmake_binary.display());
+        return Ok(cmake_binary);
+    }
+
+    let version = foundry_paths::MANAGED_CMAKE_VERSION;
+    let url = CMAKE_DOWNLOAD_URL.replace("{version}", version);
+    let cmake_dir = foundry_paths::managed_cmake_dir();
+    let temp_root = foundry_paths::application_support_dir().join("tmp");
+    std::fs::create_dir_all(&cmake_dir).map_err(|e| format!("Failed to create CMake dir: {}", e))?;
+    std::fs::create_dir_all(&temp_root).map_err(|e| format!("Failed to create temp dir: {}", e))?;
+
+    let archive_path = temp_root.join(format!("cmake-{}.tar.gz", version));
+    info!("Downloading CMake {} from {}", version, url);
+    download_file_sync(&url, &archive_path)?;
+    info!("Extracting CMake {}...", version);
+    extract_tarball(&archive_path, &cmake_dir)?;
+    let _ = std::fs::remove_file(&archive_path);
+
+    if cmake_binary.is_file() {
+        info!("Managed CMake installed at {}", cmake_binary.display());
+        Ok(cmake_binary)
+    } else {
+        Err(format!(
+            "CMake archive extracted but binary not found at {}",
+            cmake_binary.display()
+        ))
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn install_managed_node() -> Result<PathBuf, String> {
+    let npm_binary = foundry_paths::managed_npm_binary();
+    if npm_binary.is_file() {
+        info!("Managed Node.js already installed at {}", npm_binary.display());
+        return Ok(npm_binary);
+    }
+
+    let version = foundry_paths::MANAGED_NODE_VERSION;
+    let arch = macos_node_arch();
+    let url = NODE_DOWNLOAD_URL
+        .replace("{version}", version)
+        .replace("{arch}", arch);
+    let node_dir = foundry_paths::managed_node_dir();
+    let temp_root = foundry_paths::application_support_dir().join("tmp");
+    std::fs::create_dir_all(&node_dir).map_err(|e| format!("Failed to create Node dir: {}", e))?;
+    std::fs::create_dir_all(&temp_root).map_err(|e| format!("Failed to create temp dir: {}", e))?;
+
+    let archive_name = format!("node-v{}-darwin-{}.tar.gz", version, arch);
+    let archive_path = temp_root.join(&archive_name);
+    info!("Downloading Node.js {} from {}", version, url);
+    download_file_sync(&url, &archive_path)?;
+    info!("Extracting Node.js {}...", version);
+    extract_tarball(&archive_path, &node_dir)?;
+    let _ = std::fs::remove_file(&archive_path);
+
+    let node_binary = foundry_paths::managed_node_binary();
+    if node_binary.is_file() {
+        info!(
+            "Managed Node.js installed at {}",
+            node_binary.display()
+        );
+        Ok(npm_binary)
+    } else {
+        Err(format!(
+            "Node.js archive extracted but binary not found at {}",
+            node_binary.display()
+        ))
+    }
+}
+
 /// Try to acquire the install lock. Returns true if acquired.
 pub fn try_acquire_install_lock() -> bool {
     INSTALL_ACTIVE
@@ -854,6 +990,14 @@ pub fn install_cmake() -> DependencyInstallResult {
 
     #[cfg(not(target_os = "windows"))]
     {
+        #[cfg(target_os = "macos")]
+        if install_managed_cmake().is_ok() {
+            return DependencyInstallResult::verified(format!(
+                "CMake {} installed successfully.",
+                foundry_paths::MANAGED_CMAKE_VERSION
+            ));
+        }
+
         let brew = match resolve_brew_path() {
             Some(path) => path,
             None => {
@@ -1131,8 +1275,13 @@ fn ensure_npm() -> Result<String, String> {
 
     #[cfg(not(target_os = "windows"))]
     {
+        #[cfg(target_os = "macos")]
+        if let Ok(npm) = install_managed_node() {
+            return Ok(npm.to_string_lossy().to_string());
+        }
+
         let brew = resolve_brew_path().ok_or_else(|| {
-            "npm is not installed and Homebrew is not available. Please install Node.js from https://nodejs.org".to_string()
+            "npm is not installed. Please install Node.js from https://nodejs.org or install Homebrew.".to_string()
         })?;
 
         let result = silent_command(&brew)

--- a/src/pages/error.tsx
+++ b/src/pages/error.tsx
@@ -22,10 +22,15 @@ function classifyFailure(message: string) {
     lower.includes("ninja is required") ||
     lower.includes("cmake is required") ||
     lower.includes("claude code cli") ||
+    lower.includes("codex cli") ||
     lower.includes("claude_code_git_bash_path") ||
     lower.includes("git bash")
   ) {
     return { title: "Environment Not Ready", subtitle: "JUCE, Git Bash, or the local build toolchain is not configured correctly.", kind: "environment" }
+  }
+
+  if (lower.includes("ai engine not installed") || lower.includes("agent_cli_missing")) {
+    return { title: "No AI Engine", subtitle: "Install Claude Code or Codex CLI to generate plugins.", kind: "environment" }
   }
 
   if (lower.includes("did not create the required source files") || lower.includes("missing source")) {

--- a/src/pages/onboarding.tsx
+++ b/src/pages/onboarding.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react"
 import { Button } from "@/components/ui/button"
 import { FoundryLogo } from "@/components/app/foundry-logo"
 import { useAppStore } from "@/stores/app-store"
+import { useSettingsStore } from "@/stores/settings-store"
 import * as commands from "@/lib/commands"
 import { interpretDependencyInstallResult } from "@/lib/dependency-install"
 import * as analytics from "@/lib/analytics"
@@ -59,6 +60,7 @@ const DEP_KEY_BY_NAME: Record<string, string> = {
 
 const OPTIONAL_DEPS = new Set(["Codex CLI", "Claude Code CLI"])
 const PROVIDER_DEPS = new Set(["claude_code", "codex"])
+const PRIMARY_PROVIDER = "claude_code"
 
 const DEP_ORDER = [
   "Xcode Command Line Tools",
@@ -268,6 +270,7 @@ export default function Onboarding() {
   const [phase, setPhase] = useState<SetupPhase>("checking")
   const [deps, setDeps] = useState<Dep[]>([])
   const [appeared, setAppeared] = useState(false)
+  const [selectedProvider, setSelectedProvider] = useState<string>(PRIMARY_PROVIDER)
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const authPollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const abortedRef = useRef(false)
@@ -439,10 +442,8 @@ export default function Onboarding() {
     setPhase("installing")
     analytics.trackOnboardingStarted()
 
-    // Re-check first to get latest state
     const fresh = await checkDeps()
 
-    // Install required deps (build tools, cmake, git, juce)
     const missingRequired = fresh.filter(d => d.status === "missing" && d.required)
     for (const dep of missingRequired) {
       if (abortedRef.current) return
@@ -450,21 +451,20 @@ export default function Onboarding() {
       await new Promise(r => setTimeout(r, 600))
     }
 
-    // Install first available provider if none installed
     const providers = fresh.filter(d => PROVIDER_DEPS.has(d.key))
     const hasAnyProvider = providers.some(d => d.status === "installed")
     if (!hasAnyProvider) {
-      // Install Claude Code first (primary), skip if it fails and try Codex
-      const claude = providers.find(d => d.key === "claude_code" && d.status === "missing")
-      if (claude) {
-        await installSingle(claude)
+      const chosen = providers.find(d => d.key === selectedProvider && d.status === "missing")
+        ?? providers.find(d => d.key === PRIMARY_PROVIDER && d.status === "missing")
+        ?? providers.find(d => d.status === "missing")
+      if (chosen) {
+        await installSingle(chosen)
         await new Promise(r => setTimeout(r, 600))
       }
     }
 
-    // Final recheck
     await checkDeps()
-  }, [checkDeps, installSingle])
+  }, [checkDeps, installSingle, selectedProvider])
 
   // ---- Initial check on mount ----
 
@@ -509,6 +509,7 @@ export default function Onboarding() {
   const finish = async () => {
     analytics.trackOnboardingCompleted()
     await commands.completeOnboarding()
+    await useSettingsStore.getState().refreshModels()
     useAppStore.getState().checkOnboarding()
   }
 
@@ -619,7 +620,7 @@ export default function Onboarding() {
                         </span>
                         {PROVIDER_DEPS.has(dep.key) && (
                           <span className="text-[10px] uppercase tracking-wider text-muted-foreground/50 font-medium">
-                            {hasProvider ? "Optional" : "Pick one"}
+                            {hasProvider ? "Optional" : dep.key === selectedProvider ? "Recommended" : "Alternative"}
                           </span>
                         )}
                       </div>
@@ -643,15 +644,26 @@ export default function Onboarding() {
                       {dep.status === "installed" && "Ready"}
                       {dep.status === "installing" && pct !== undefined && `${pct}%`}
                       {dep.status === "missing" && (
-                        <Button
-                          size="sm"
-                          variant="secondary"
-                          disabled={isInstalling}
-                          onClick={() => installSingle(dep)}
-                          className="text-[11px] h-6 px-2"
-                        >
-                          Install
-                        </Button>
+                        PROVIDER_DEPS.has(dep.key) && !hasProvider && !isInstalling ? (
+                          <Button
+                            size="sm"
+                            variant={dep.key === selectedProvider ? "default" : "secondary"}
+                            onClick={() => setSelectedProvider(dep.key)}
+                            className="text-[11px] h-6 px-2"
+                          >
+                            {dep.key === selectedProvider ? "Selected" : "Select"}
+                          </Button>
+                        ) : (
+                          <Button
+                            size="sm"
+                            variant="secondary"
+                            disabled={isInstalling}
+                            onClick={() => installSingle(dep)}
+                            className="text-[11px] h-6 px-2"
+                          >
+                            Install
+                          </Button>
+                        )
                       )}
                       {dep.status === "auth_required" && (
                         <Button

--- a/src/pages/prompt.tsx
+++ b/src/pages/prompt.tsx
@@ -97,8 +97,20 @@ export default function Prompt() {
   const modelCatalog = useSettingsStore((s) => s.modelCatalog)
   const installPaths = useSettingsStore((s) => s.installPaths)
   const [prompt, setPrompt] = useState("")
-  const [selectedAgent, setSelectedAgent] = useState("Claude Code")
-  const [selectedModel, setSelectedModel] = useState("sonnet")
+  const [selectedAgent, setSelectedAgent] = useState(
+    () => {
+      const catalog = useSettingsStore.getState().modelCatalog
+      const first = catalog[0]
+      return first?.name ?? "Claude Code"
+    }
+  )
+  const [selectedModel, setSelectedModel] = useState(
+    () => {
+      const catalog = useSettingsStore.getState().modelCatalog
+      const defaultModel = catalog[0]?.models.find(m => m.default)
+      return defaultModel?.flag ?? defaultModel?.id ?? "sonnet"
+    }
+  )
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
   const isEmpty = !prompt.trim()
 

--- a/src/stores/build-store.ts
+++ b/src/stores/build-store.ts
@@ -15,6 +15,7 @@ import {
   trackRefineStarted,
 } from "@/lib/analytics";
 import { useAppStore } from "@/stores/app-store";
+import { useSettingsStore } from "@/stores/settings-store";
 
 function stripDebugConfig(config: GenerationConfig): GenerationConfig {
   const { debugPipeline, debugContext, ...baseConfig } = config;
@@ -106,12 +107,18 @@ function inferFormat(plugin: Plugin): GenerationConfig["format"] {
 
 function inferAgent(plugin: Plugin): string {
   if (plugin.generationConfig?.agent) return plugin.generationConfig.agent;
-  if (plugin.agent === "Codex") return "Codex";
-  return "Claude Code";
+  if (plugin.agent) return plugin.agent;
+  const catalog = useSettingsStore.getState().modelCatalog;
+  return catalog[0]?.name ?? "Claude Code";
 }
 
 function inferModel(plugin: Plugin): string {
-  return plugin.generationConfig?.model || plugin.model?.flag || plugin.model?.id || "sonnet";
+  if (plugin.generationConfig?.model) return plugin.generationConfig.model;
+  if (plugin.model?.flag) return plugin.model.flag;
+  if (plugin.model?.id) return plugin.model.id;
+  const catalog = useSettingsStore.getState().modelCatalog;
+  const defaultModel = catalog[0]?.models.find(m => m.default);
+  return defaultModel?.flag ?? defaultModel?.id ?? "sonnet";
 }
 
 function buildRetryConfig(plugin: Plugin): GenerationConfig {

--- a/src/test/onboarding-logic.test.ts
+++ b/src/test/onboarding-logic.test.ts
@@ -161,6 +161,18 @@ describe("onboarding readiness logic", () => {
     return { allReady, hasProvider, allRequiredReady, hasAuthRequired, hasFailed }
   }
 
+  it("reports allReady when all required installed + Codex provider ready", () => {
+    const deps: Dep[] = [
+      mapDependency({ name: "Xcode Command Line Tools", installed: true, authRequired: false }),
+      mapDependency({ name: "CMake", installed: true, authRequired: false }),
+      mapDependency({ name: "Claude Code CLI", installed: false, authRequired: false }),
+      mapDependency({ name: "Codex CLI", installed: true, authRequired: false }),
+    ]
+    const r = computeReadiness(deps)
+    expect(r.allReady).toBe(true)
+    expect(r.hasProvider).toBe(true)
+  })
+
   it("reports allReady when all required installed + provider ready", () => {
     const deps: Dep[] = [
       mapDependency({ name: "Xcode Command Line Tools", installed: true, authRequired: false }),


### PR DESCRIPTION
## Summary

Enables onboarding on fresh macOS machines without requiring Homebrew or sudo access.

- Downloads CMake 3.31.6 and Node.js 22.14.0 directly from GitHub/Kitware and nodejs.org to `~/Library/Application Support/Foundry/`
- Falls back to managed tool paths when shell PATH doesn't have cmake/npm/node
- Makes build environment check agent-agnostic (any provider, not just Claude)
- Adds provider selection UI in onboarding (pick Claude Code or Codex)
- Refreshes model catalog after onboarding so next screen sees installed provider
- Gates managed installs to macOS only to avoid Linux cross-platform issues

Fixes #255