### PR TITLE
fix: onboarding — codex shim bypass, provider CTA, auth step transition

### DIFF
--- a/src-tauri/src/services/onboarding.rs
+++ b/src-tauri/src/services/onboarding.rs
@@ -2205,18 +2205,14 @@ pub fn install_claude_code() -> DependencyInstallDispatchResult {
 
 /// Install Codex CLI using the native binary from GitHub releases (macOS).
 /// Falls back to npm on non-macOS platforms or if the native install fails.
+/// Unlike `install_claude()`, this function does NOT check for an existing system
+/// Codex binary first — doing so would bypass the native install when a broken
+/// Homebrew shim (e.g. `#!/usr/bin/env node` with incomplete PATH) is present.
 pub fn install_codex() -> DependencyInstallDispatchResult {
-    if let Some(existing_path) = platform::resolve_codex_path() {
-        info!("Codex already resolvable at {}", existing_path);
-        return DependencyInstallDispatchResult::Provider(ProviderInstallPreparation {
-            provider: ProviderCli::Codex,
-            installer: "existing",
-            npm_path: None,
-            expected_path: Some(existing_path),
-        });
-    }
-
     // Strategy 1 (macOS): Download the official native binary from GitHub releases.
+    // Always attempt this first, even if a system codex binary is already on PATH,
+    // because any such binary may be a broken shim. The native install lands in
+    // Foundry's managed directory and is health-checked before being returned.
     #[cfg(target_os = "macos")]
     {
         match install_managed_codex() {

--- a/src/pages/onboarding.tsx
+++ b/src/pages/onboarding.tsx
@@ -471,11 +471,13 @@ export default function Onboarding() {
     analytics.trackOnboardingStarted()
     const fresh = await checkDeps()
     const providerDep = fresh.find(d => d.key === selectedProvider)
-    if (!providerDep || providerDep.status !== "missing") return
-    setInstallingDep(providerDep.key)
-    await installSingle(providerDep)
-    setInstallingDep(null)
-    await new Promise(r => setTimeout(r, 600))
+    if (!providerDep) return
+    if (providerDep.status === "missing") {
+      setInstallingDep(providerDep.key)
+      await installSingle(providerDep)
+      setInstallingDep(null)
+      await new Promise(r => setTimeout(r, 600))
+    }
     // Refresh state — if installed and needs auth go to auth step, else done
     const recheck = await commands.getSetupState()
     const needsAuth = recheck.providers.some(p => p.status === "installed_needs_auth")
@@ -809,14 +811,21 @@ export default function Onboarding() {
 
                 <div className="flex flex-col items-center gap-3">
                   {!isInstalling && (
-                    <Button
-                      size="lg"
-                      onClick={installSelectedProvider}
-                      className="w-full"
-                      disabled={!deps.find(d => d.key === selectedProvider && d.status === "missing")}
-                    >
-                      Install {deps.find(d => d.key === selectedProvider)?.label ?? "engine"}
-                    </Button>
+                    (() => {
+                      const selectedDep = deps.find(d => d.key === selectedProvider)
+                      if (!selectedDep) return null
+                      const isMissing = selectedDep.status === "missing"
+                      return (
+                        <Button
+                          size="lg"
+                          onClick={installSelectedProvider}
+                          className="w-full"
+                          disabled={isInstalling}
+                        >
+                          {isMissing ? `Install ${selectedDep.label}` : "Continue"}
+                        </Button>
+                      )
+                    })()
                   )}
                   {isInstalling && (
                     <Button size="lg" disabled className="w-full">
@@ -894,24 +903,41 @@ export default function Onboarding() {
                 </div>
 
                 <div className="flex flex-col items-center gap-3">
-                  {hasAuthRequired && !isInstalling && (
+                  {!isInstalling && (
                     <div className="flex flex-col items-center gap-2 w-full">
-                      <p className="text-[12px] text-muted-foreground text-center">
-                        Complete the sign-in in your browser, then click Continue.
-                      </p>
-                      <Button
-                        variant="secondary"
-                        onClick={async () => {
-                          await checkDeps()
-                          const s = await commands.getSetupState()
-                          if (s.providers.some(p => p.status === "installed_and_authenticated")) {
-                            setStep("done")
-                          }
-                        }}
-                        className="w-full"
-                      >
-                        Continue
-                      </Button>
+                      {hasAuthRequired ? (
+                        <>
+                          <p className="text-[12px] text-muted-foreground text-center">
+                            Complete the sign-in in your browser, then click Continue.
+                          </p>
+                          <Button
+                            variant="secondary"
+                            onClick={async () => {
+                              await checkDeps()
+                              const s = await commands.getSetupState()
+                              if (s.providers.some(p => p.status === "installed_and_authenticated")) {
+                                setStep("done")
+                              }
+                            }}
+                            className="w-full"
+                          >
+                            Continue
+                          </Button>
+                        </>
+                      ) : (
+                        <Button
+                          variant="secondary"
+                          onClick={async () => {
+                            const s = await commands.getSetupState()
+                            if (s.providers.some(p => p.status === "installed_and_authenticated")) {
+                              setStep("done")
+                            }
+                          }}
+                          className="w-full"
+                        >
+                          Continue
+                        </Button>
+                      )}
                     </div>
                   )}
                   <Button


### PR DESCRIPTION
## Summary

3 critical onboarding bug fixes:

- **Bug 1 — Codex shim bypass** (`onboarding.rs`): `install_codex()` no longer short-circuits to an existing broken Homebrew shim before attempting the native GitHub install. The shortcut `if let Some(existing_path) = platform::resolve_codex_path()` has been removed.
- **Bug 2 — Provider CTA disabled** (`onboarding.tsx`): `installSelectedProvider` no longer returns early when the provider status is not `"missing"`. Button now shows "Continue" instead of "Install" when the provider is already installed.
- **Bug 3 — Auth step stuck** (`onboarding.tsx`): The Continue button is now always rendered in the auth step (not guarded by `hasAuthRequired`). When the user is already authenticated, the explanatory text is hidden but the button remains, allowing progression to done.

## Validation

- `cargo clippy --lib -- -D warnings` ✅
- `cargo test --lib` — 43 passed ✅
- `npm run typecheck` ✅
- `npm test` — 54 passed ✅